### PR TITLE
Implement view_photos against darktable's SQLite library

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,14 @@
 
 A Model Context Protocol (MCP) server that exposes a small set of darktable
 operations to MCP clients (e.g. Claude Desktop, Claude Code). The AI lives in
-the client; this server just shells out to `darktable-cli`.
+the client; this server just shells out to `darktable-cli` and reads
+darktable's SQLite library.
 
 ## Status
 
-Early alpha. Currently only `export_images` is wired through to `darktable-cli`.
-The other tools are registered but return a "not yet implemented" message.
+Early alpha. `view_photos` and `export_images` are wired through to real
+darktable; the remaining tools are registered but return a "not yet
+implemented" message.
 
 ## Installation
 
@@ -36,22 +38,28 @@ Add to your Claude Desktop config:
 }
 ```
 
+If your `library.db` is in a non-standard location, set `DARKTABLE_LIBRARY`
+to its absolute path.
+
 ## Implemented tools
 
+- `view_photos(filter?, rating_min?, limit?)` — reads darktable's `library.db`
+  and returns id, rating (-1 = rejected, 0–5 = stars), and absolute path per
+  row. The filter is a substring match against folder or filename.
 - `export_images(photo_ids, output_path, format, quality?)` — exports each
   source file via `darktable-cli` to the given output directory.
 
 ## Stubbed tools (registered, not implemented)
 
-- `view_photos`, `rate_photos`, `import_batch`, `adjust_exposure`,
-  `apply_preset`
+- `rate_photos`, `import_batch`, `adjust_exposure`, `apply_preset`
 
 ## Usage example
 
-> "Export these RAWs as JPEGs at quality 90 into ~/exports."
+> "Show me my 4-star photos from the 2025 folder, then export them as JPEGs
+> at quality 90 into ~/exports."
 
-The AI client then calls `export_images` with the file paths, output
-directory, format `jpeg`, and quality `90`.
+The AI client calls `view_photos` to find candidates, then `export_images`
+with the resulting file paths.
 
 ## Requirements
 

--- a/darktable_mcp/darktable/__init__.py
+++ b/darktable_mcp/darktable/__init__.py
@@ -1,6 +1,13 @@
 """Darktable integration layer."""
 
-from .lua_executor import LuaExecutor
 from .cli_wrapper import CLIWrapper
+from .library_db import LibraryDB, LibraryNotFoundError, PhotoRow
+from .lua_executor import LuaExecutor
 
-__all__ = ["LuaExecutor", "CLIWrapper"]
+__all__ = [
+    "CLIWrapper",
+    "LibraryDB",
+    "LibraryNotFoundError",
+    "LuaExecutor",
+    "PhotoRow",
+]

--- a/darktable_mcp/darktable/library_db.py
+++ b/darktable_mcp/darktable/library_db.py
@@ -1,0 +1,105 @@
+"""Read-only access to darktable's SQLite library."""
+
+import os
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional
+
+from ..utils.errors import DarktableMCPError
+
+
+class LibraryNotFoundError(DarktableMCPError):
+    """Raised when darktable's library.db cannot be located."""
+
+
+@dataclass
+class PhotoRow:
+    id: int
+    path: str
+    rating: int  # -1 = rejected, 0–5 = stars
+
+
+def _candidate_paths() -> List[Path]:
+    home = Path.home()
+    paths: List[Path] = []
+
+    env_path = os.environ.get("DARKTABLE_LIBRARY")
+    if env_path:
+        paths.append(Path(env_path))
+
+    paths.append(home / ".config" / "darktable" / "library.db")
+
+    localappdata = os.environ.get("LOCALAPPDATA")
+    if localappdata:
+        paths.append(Path(localappdata) / "darktable" / "library.db")
+    appdata = os.environ.get("APPDATA")
+    if appdata:
+        paths.append(Path(appdata) / "darktable" / "library.db")
+
+    paths.append(home / "Library" / "Application Support" / "darktable" / "library.db")
+    return paths
+
+
+class LibraryDB:
+    """Thin read-only wrapper around darktable's library.db."""
+
+    def __init__(self, db_path: Optional[Path] = None) -> None:
+        resolved: Optional[Path] = Path(db_path) if db_path is not None else None
+        if resolved is None:
+            for candidate in _candidate_paths():
+                if candidate.is_file():
+                    resolved = candidate
+                    break
+        if resolved is None or not resolved.is_file():
+            raise LibraryNotFoundError(
+                "Could not locate darktable library.db. "
+                "Set DARKTABLE_LIBRARY env var or pass db_path explicitly."
+            )
+        self.db_path = resolved
+
+    def _connect(self) -> sqlite3.Connection:
+        # mode=ro is enough; we deliberately don't pass immutable=1 because
+        # darktable may be writing to the file concurrently.
+        uri = f"file:{self.db_path}?mode=ro"
+        return sqlite3.connect(uri, uri=True)
+
+    def view_photos(
+        self,
+        rating_min: Optional[int] = None,
+        filter_text: Optional[str] = None,
+        limit: int = 50,
+    ) -> List[PhotoRow]:
+        clauses: List[str] = []
+        params: List[object] = []
+
+        if rating_min is not None:
+            clauses.append("(i.flags & 7) >= ?")
+            clauses.append("(i.flags & 8) = 0")
+            params.append(int(rating_min))
+
+        if filter_text:
+            clauses.append("(fr.folder LIKE ? OR i.filename LIKE ?)")
+            like = f"%{filter_text}%"
+            params.extend([like, like])
+
+        where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+        sql = (
+            "SELECT i.id, fr.folder, i.filename, i.flags "
+            "FROM images i "
+            "JOIN film_rolls fr ON i.film_id = fr.id "
+            f"{where} "
+            "ORDER BY i.id DESC "
+            "LIMIT ?"
+        )
+        params.append(int(limit))
+
+        with self._connect() as conn:
+            rows = conn.execute(sql, params).fetchall()
+
+        result: List[PhotoRow] = []
+        for image_id, folder, filename, flags in rows:
+            rating = -1 if (flags & 8) else (flags & 7)
+            path = str(Path(folder) / filename)
+            result.append(PhotoRow(id=int(image_id), path=path, rating=int(rating)))
+        return result

--- a/darktable_mcp/server.py
+++ b/darktable_mcp/server.py
@@ -9,6 +9,7 @@ from mcp.server.stdio import stdio_server
 from mcp.types import TextContent, Tool
 
 from .darktable.cli_wrapper import CLIWrapper
+from .darktable.library_db import LibraryDB
 from .utils.errors import DarktableMCPError
 
 logger = logging.getLogger(__name__)
@@ -22,6 +23,7 @@ class DarktableMCPServer:
     def __init__(self) -> None:
         self.app: Server = Server("darktable-mcp")
         self._cli: Optional[CLIWrapper] = None
+        self._library: Optional[LibraryDB] = None
         self._handler_map: Dict[str, ToolHandler] = self._build_handlers()
         self._setup_tools()
 
@@ -30,6 +32,12 @@ class DarktableMCPServer:
         if self._cli is None:
             self._cli = CLIWrapper()
         return self._cli
+
+    @property
+    def library(self) -> LibraryDB:
+        if self._library is None:
+            self._library = LibraryDB()
+        return self._library
 
     def _setup_tools(self) -> None:
         @self.app.list_tools()
@@ -54,13 +62,19 @@ class DarktableMCPServer:
         return [
             Tool(
                 name="view_photos",
-                description="Browse photo library with optional filters (not yet implemented)",
+                description=(
+                    "Browse darktable's library with optional filters. "
+                    "Returns id, rating (-1 = rejected, 0–5 = stars), and path."
+                ),
                 inputSchema={
                     "type": "object",
                     "properties": {
-                        "filter": {"type": "string", "description": "Filter criteria"},
+                        "filter": {
+                            "type": "string",
+                            "description": "Substring matched against folder or filename",
+                        },
                         "rating_min": {"type": "integer", "minimum": 1, "maximum": 5},
-                        "limit": {"type": "integer"},
+                        "limit": {"type": "integer", "minimum": 1, "maximum": 1000},
                     },
                 },
             ),
@@ -141,7 +155,7 @@ class DarktableMCPServer:
 
     def _build_handlers(self) -> Dict[str, ToolHandler]:
         return {
-            "view_photos": self._not_implemented("view_photos"),
+            "view_photos": self._handle_view_photos,
             "rate_photos": self._not_implemented("rate_photos"),
             "import_batch": self._not_implemented("import_batch"),
             "adjust_exposure": self._not_implemented("adjust_exposure"),
@@ -158,9 +172,24 @@ class DarktableMCPServer:
         async def handler(_: Dict[str, Any]) -> List[TextContent]:
             return [TextContent(
                 type="text",
-                text=f"{name} is not yet implemented. Currently only export_images is wired.",
+                text=f"{name} is not yet implemented.",
             )]
         return handler
+
+    async def _handle_view_photos(self, arguments: Dict[str, Any]) -> List[TextContent]:
+        rating_min = arguments.get("rating_min")
+        filter_text = arguments.get("filter")
+        limit = int(arguments.get("limit", 50))
+
+        rows = self.library.view_photos(
+            rating_min=rating_min,
+            filter_text=filter_text,
+            limit=limit,
+        )
+        if not rows:
+            return [TextContent(type="text", text="No photos found.")]
+        body = "\n".join(f"#{r.id}\trating={r.rating:>2}\t{r.path}" for r in rows)
+        return [TextContent(type="text", text=body)]
 
     async def _handle_export_images(self, arguments: Dict[str, Any]) -> List[TextContent]:
         photo_ids = arguments.get("photo_ids") or []

--- a/tests/test_library_db.py
+++ b/tests/test_library_db.py
@@ -1,0 +1,85 @@
+"""Tests for LibraryDB against a synthetic darktable schema."""
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from darktable_mcp.darktable.library_db import LibraryDB, LibraryNotFoundError
+
+
+def _make_library(db_path: Path) -> None:
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE film_rolls (id INTEGER PRIMARY KEY, folder TEXT);
+            CREATE TABLE images (
+                id INTEGER PRIMARY KEY,
+                film_id INTEGER,
+                filename TEXT,
+                flags INTEGER
+            );
+            INSERT INTO film_rolls (id, folder) VALUES (1, '/photos/2024');
+            INSERT INTO film_rolls (id, folder) VALUES (2, '/photos/2025');
+            INSERT INTO images (id, film_id, filename, flags) VALUES (1, 1, 'a.raw', 5);
+            INSERT INTO images (id, film_id, filename, flags) VALUES (2, 1, 'b.raw', 8);
+            INSERT INTO images (id, film_id, filename, flags) VALUES (3, 2, 'c.raw', 2);
+            INSERT INTO images (id, film_id, filename, flags) VALUES (4, 2, 'd.jpg', 4);
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_view_photos_no_filter(tmp_path):
+    db = tmp_path / "library.db"
+    _make_library(db)
+
+    rows = LibraryDB(db_path=db).view_photos()
+
+    assert len(rows) == 4
+    assert rows[0].id == 4  # ORDER BY id DESC
+    by_filename = {Path(r.path).name: r for r in rows}
+    assert by_filename["a.raw"].rating == 5
+    assert by_filename["b.raw"].rating == -1  # rejected (flag bit 3)
+    assert by_filename["c.raw"].rating == 2
+    assert by_filename["a.raw"].path == "/photos/2024/a.raw"
+
+
+def test_view_photos_rating_min_excludes_rejected(tmp_path):
+    db = tmp_path / "library.db"
+    _make_library(db)
+
+    rows = LibraryDB(db_path=db).view_photos(rating_min=4)
+
+    assert {Path(r.path).name for r in rows} == {"a.raw", "d.jpg"}
+    assert all(r.rating >= 4 for r in rows)
+
+
+def test_view_photos_filter_substring(tmp_path):
+    db = tmp_path / "library.db"
+    _make_library(db)
+
+    rows = LibraryDB(db_path=db).view_photos(filter_text="2025")
+
+    assert {Path(r.path).name for r in rows} == {"c.raw", "d.jpg"}
+
+
+def test_view_photos_limit(tmp_path):
+    db = tmp_path / "library.db"
+    _make_library(db)
+
+    rows = LibraryDB(db_path=db).view_photos(limit=2)
+
+    assert len(rows) == 2
+
+
+def test_missing_library_raises(tmp_path, monkeypatch):
+    monkeypatch.delenv("DARKTABLE_LIBRARY", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+
+    with pytest.raises(LibraryNotFoundError):
+        LibraryDB()


### PR DESCRIPTION
## Summary

- Adds `darktable_mcp/darktable/library_db.py`: a stdlib-only read-only reader for darktable's `library.db`. Joins `images` with `film_rolls` to build absolute paths; decodes rating from the `flags` column (low 3 bits = stars, bit 3 = rejected).
- Auto-discovers `library.db` from `$DARKTABLE_LIBRARY`, then `~/.config/darktable/`, `%LOCALAPPDATA%`, `%APPDATA%`, `~/Library/Application Support/darktable/`. Opens via `sqlite3` URI in `mode=ro` so reads coexist with a running darktable.
- Wires `view_photos` through `LibraryDB.view_photos(rating_min, filter_text, limit)` and surfaces id, rating, and path.
- Tests cover no-filter, `rating_min` (excludes rejected via flag bit 3), substring filter, limit, and the missing-file error path against a synthetic schema.

Replaces #2 — squash-merge of #1 produced a structural conflict on the prior branch's history; this PR is rebased cleanly off `main`.

## Test plan

- [ ] `pytest tests/test_library_db.py` passes
- [ ] `view_photos` against a real darktable library returns expected rows for `rating_min=4`
- [ ] Setting `DARKTABLE_LIBRARY` overrides discovery

---
_Generated by [Claude Code](https://claude.ai/code/session_01L7M2UPeQbF3kReLGVAEPVH)_