### PR TITLE
Follow-ups: mcp 2.x port, release pipeline, lint gate, camera gap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,14 +57,12 @@ jobs:
         run: python -m pytest -q
 
   lint:
-    name: lint (advisory)
+    name: lint
     runs-on: ubuntu-latest
-    # Advisory only: the tree carries a pre-existing lint backlog (~143 ruff findings
-    # across server.py, tools/preview_tools.py and tools/camera_tools.py, plus 13 files
-    # black would reformat) that is outside the scope of the change adding this
-    # workflow. Drop continue-on-error once that backlog is cleared, so lint becomes a
-    # real gate instead of a report nobody is required to read.
-    continue-on-error: true
+    # A real gate as of the backlog cleanup: `ruff check .` and `black --check .`
+    # are both clean on the whole tree, so any new finding is genuinely new.
+    # Do NOT re-add continue-on-error to get a red build green — fix the finding,
+    # or change the rule in pyproject.toml so the exemption is explicit.
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,10 @@ on:
   # Weekly run against a fresh dependency resolution. Push/PR builds only prove the
   # code still works against the deps that existed when it was written; the scheduled
   # run is what catches an upstream release breaking us with no commit of our own
-  # (e.g. mcp 2.0.0 dropping the @server.list_tools() / @server.call_tool() decorators).
+  # This is not hypothetical: mcp 2.0.0 dropped the @server.list_tools() /
+  # @server.call_tool() decorators and broke this server on a clean install,
+  # with no commit of ours in between. We have since ported to the 2.x
+  # handlers; the cron is here to catch the next one.
   schedule:
     - cron: '17 4 * * 1'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,401 @@
+name: Release
+
+# Two entry points, deliberately asymmetric:
+#
+#   * push of a `v*` tag  -> the real release. Tests, build, artifact
+#                            verification, then publish to PyPI.
+#   * workflow_dispatch   -> a rehearsal. Same tests, same build, same
+#                            verification, and optionally an upload to
+#                            TestPyPI so the OIDC path can be exercised
+#                            without burning a version number on the real
+#                            index. It can never publish to PyPI.
+#
+# A plain branch push does not trigger this workflow at all, and both publish
+# jobs additionally guard on the event, so no branch push can reach an upload.
+# Branch/PR coverage lives in ci.yml.
+#
+# ---------------------------------------------------------------------------
+# ONE-TIME MANUAL SETUP ON PYPI (must be done before the first release)
+# ---------------------------------------------------------------------------
+# This workflow uses PyPI Trusted Publishing (OIDC). There is no API token in
+# repo secrets, so there is no long-lived credential to leak or rotate. In
+# exchange, the publisher has to be registered once on PyPI's side.
+#
+# `darktable-mcp` does not exist on PyPI yet, so use the *pending* publisher
+# form (it creates the project on the first successful upload):
+#
+#   https://pypi.org/manage/account/publishing/
+#
+#     PyPI Project Name:  darktable-mcp
+#     Owner:              w1ne
+#     Repository name:    darktable-mcp
+#     Workflow name:      release.yml
+#     Environment name:   pypi
+#
+# Then repeat the same form on TestPyPI if you want the rehearsal path:
+#
+#   https://test.pypi.org/manage/account/publishing/
+#
+#     PyPI Project Name:  darktable-mcp
+#     Owner:              w1ne
+#     Repository name:    darktable-mcp
+#     Workflow name:      release.yml
+#     Environment name:   testpypi
+#
+# Finally create the two GitHub environments (Settings -> Environments):
+# `pypi` and `testpypi`. The environment name must match the value registered
+# above exactly, or PyPI rejects the OIDC token. Adding required reviewers to
+# the `pypi` environment is optional but recommended: it turns the upload into
+# a deliberate button press.
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      publish-testpypi:
+        description: 'Also upload the built artifacts to TestPyPI (rehearsal)'
+        type: boolean
+        default: false
+
+# Least privilege by default. `id-token: write` is granted per job, only to the
+# two publish jobs that actually need to mint an OIDC token.
+permissions:
+  contents: read
+
+concurrency:
+  # Serialize per tag. Do NOT cancel in progress: cancelling a half-finished
+  # upload is worse than letting it complete.
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Gate 1: the suite. Mirrors ci.yml's `test` job, including the Lua
+  # interpreter and DARKTABLE_MCP_REQUIRE_LUA=1 so the dispatcher tests cannot
+  # silently skip. Nothing downstream runs unless this is green on every
+  # supported interpreter -- publishing an artifact whose suite never ran is
+  # the whole failure mode this job exists to prevent.
+  # ---------------------------------------------------------------------------
+  test:
+    name: test (py${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Same matrix as ci.yml. 3.10 is the real floor: every mcp release in
+        # the pinned range declares Requires-Python >=3.10.
+        python-version: ['3.10', '3.11', '3.13']
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Lua interpreter
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y lua5.4
+          command -v lua || sudo ln -s "$(command -v lua5.4)" /usr/local/bin/lua
+          lua -v
+
+      - name: Install package
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e '.[dev]'
+
+      - name: Run tests
+        env:
+          DARKTABLE_MCP_REQUIRE_LUA: '1'
+        run: python -m pytest -q
+
+  # ---------------------------------------------------------------------------
+  # Gate 2: build the artifacts and prove they are the ones we meant to ship.
+  # Everything a user hits on `pip install darktable-mcp` is checked here, from
+  # an environment that cannot be rescued by the source tree.
+  # ---------------------------------------------------------------------------
+  build:
+    name: build and verify artifacts
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      # The sdist self-test below runs tests/test_lua_dispatcher.py for real.
+      - name: Install Lua interpreter
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y lua5.4
+          command -v lua || sudo ln -s "$(command -v lua5.4)" /usr/local/bin/lua
+          lua -v
+
+      # Read __version__ without importing the package: importing it drags in
+      # `mcp`, and this step must work before anything is installed.
+      - name: Read declared package version
+        id: ver
+        run: |
+          python - <<'PY' >> "$GITHUB_OUTPUT"
+          import ast
+          import pathlib
+
+          src = pathlib.Path("darktable_mcp/__init__.py").read_text(encoding="utf-8")
+          for node in ast.parse(src).body:
+              if isinstance(node, ast.Assign) and any(
+                  isinstance(t, ast.Name) and t.id == "__version__" for t in node.targets
+              ):
+                  print("version=" + ast.literal_eval(node.value))
+                  break
+          else:
+              raise SystemExit("no __version__ assignment in darktable_mcp/__init__.py")
+          PY
+
+      # A tag/version mismatch is the classic way a release ships the wrong
+      # number: `git tag v0.3.0` on a tree that still says __version__ = "0.2.0"
+      # uploads 0.2.0 and permanently burns that version on PyPI.
+      - name: Guard - git tag must match darktable_mcp.__version__
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          PKG_VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          set -euo pipefail
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::tag ${GITHUB_REF_NAME} means version ${TAG_VERSION}, but darktable_mcp.__version__ is ${PKG_VERSION}. Fix darktable_mcp/__init__.py or re-tag; do not publish."
+            exit 1
+          fi
+          echo "tag ${GITHUB_REF_NAME} matches darktable_mcp.__version__ = ${PKG_VERSION}"
+
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+
+      - name: Build sdist and wheel
+        run: python -m build
+
+      - name: twine check
+        # --strict: a metadata warning becomes an error. PyPI renders the long
+        # description from this metadata; a warning here is a broken project page.
+        run: twine check --strict dist/*
+
+      # The artifacts are opaque once uploaded. Assert their contents now.
+      - name: Verify artifact contents
+        run: |
+          python - <<'PY'
+          import pathlib
+          import sys
+          import tarfile
+          import zipfile
+
+          dist = pathlib.Path("dist")
+          sdists = sorted(dist.glob("*.tar.gz"))
+          wheels = sorted(dist.glob("*.whl"))
+          assert len(sdists) == 1, f"expected exactly one sdist, got {sdists}"
+          assert len(wheels) == 1, f"expected exactly one wheel, got {wheels}"
+
+          with tarfile.open(sdists[0]) as tf:
+              sdist_names = tf.getnames()
+          with zipfile.ZipFile(wheels[0]) as zf:
+              wheel_names = zf.namelist()
+
+          root = sdist_names[0].split("/")[0]
+          rel = {n[len(root) + 1:] for n in sdist_names if n.startswith(root + "/")}
+
+          failures = []
+
+          # The wheel is what `pip install darktable-mcp` unpacks. If the Lua
+          # plugin is not in it, `darktable-mcp install-plugin` -- the very first
+          # command every user runs -- dies on importlib.resources.
+          if "darktable_mcp/lua/darktable_mcp.lua" not in wheel_names:
+              failures.append(
+                  "wheel is missing darktable_mcp/lua/darktable_mcp.lua; check "
+                  "[tool.setuptools.package-data] in pyproject.toml"
+              )
+
+          # The sdist has to be a buildable, testable copy of the project.
+          # setuptools' sdist defaults pick up tests/test_*.py but NOT
+          # tests/__init__.py and NOT non-.py fixtures such as the Lua file the
+          # dispatcher test executes, so MANIFEST.in has to graft them.
+          for name in (
+              "darktable_mcp/lua/darktable_mcp.lua",
+              "tests/__init__.py",
+              "tests/lua/test_dispatcher.lua",
+              "pyproject.toml",
+              "README.md",
+              "LICENSE",
+          ):
+              if name not in rel:
+                  failures.append(f"sdist is missing {name}")
+          if not any(n.startswith("tests/test_") and n.endswith(".py") for n in rel):
+              failures.append("sdist carries no tests/test_*.py")
+
+          junk_prefixes = (
+              ".venv/", "venv/", "build/", "dist/", ".git/",
+              ".mypy_cache/", ".pytest_cache/", ".ruff_cache/",
+          )
+          for n in sorted(rel):
+              if (
+                  n.startswith(junk_prefixes)
+                  or "__pycache__/" in n
+                  or n.endswith((".pyc", ".pyo"))
+              ):
+                  failures.append(f"sdist contains junk: {n}")
+
+          if failures:
+              print("ARTIFACT CHECK FAILED:")
+              for f in failures:
+                  print("  -", f)
+              sys.exit(1)
+
+          print(f"sdist {sdists[0].name}: {len(rel)} entries, lua + tests present, no junk")
+          print(f"wheel {wheels[0].name}: {len(wheel_names)} entries, lua present")
+          PY
+
+      # A sdist that cannot build and test itself is not a release artifact,
+      # it is a tarball. Unpack it somewhere the repo checkout cannot help it
+      # and run the real suite out of it.
+      - name: Verify the sdist is self-contained
+        run: |
+          set -euo pipefail
+          SDIST="$(ls "$GITHUB_WORKSPACE"/dist/*.tar.gz)"
+          UNPACK="$RUNNER_TEMP/sdist-check"
+          rm -rf "$UNPACK" "$RUNNER_TEMP/sdist-venv"
+          mkdir -p "$UNPACK"
+          tar xzf "$SDIST" -C "$UNPACK"
+          SRC="$(find "$UNPACK" -mindepth 1 -maxdepth 1 -type d)"
+          python -m venv "$RUNNER_TEMP/sdist-venv"
+          "$RUNNER_TEMP/sdist-venv/bin/python" -m pip install --upgrade pip
+          "$RUNNER_TEMP/sdist-venv/bin/python" -m pip install "${SRC}[dev]"
+          cd "$SRC"
+          DARKTABLE_MCP_REQUIRE_LUA=1 "$RUNNER_TEMP/sdist-venv/bin/python" -m pytest -q
+
+      # The check that matters most, and the one that is easy to fake: install
+      # the wheel into a venv outside the checkout and exercise it from a
+      # working directory that is NOT the repo. Running this from the repo root
+      # would let the source tree satisfy every import and hide a data file
+      # that never made it into the wheel.
+      - name: Verify the installed wheel from outside the checkout
+        env:
+          PKG_VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          set -euo pipefail
+          WHEEL="$(ls "$GITHUB_WORKSPACE"/dist/*.whl)"
+          VENV="$RUNNER_TEMP/wheel-venv"
+          WORK="$RUNNER_TEMP/wheel-work"
+          FAKE_HOME="$RUNNER_TEMP/fake-home"
+          rm -rf "$VENV" "$WORK" "$FAKE_HOME"
+          mkdir -p "$WORK" "$FAKE_HOME"
+          python -m venv "$VENV"
+          "$VENV/bin/python" -m pip install --upgrade pip
+          "$VENV/bin/python" -m pip install "$WHEEL"
+
+          cd "$WORK"
+          "$VENV/bin/python" - <<'PY'
+          import importlib.metadata
+          import importlib.resources
+          import os
+
+          import darktable_mcp
+
+          expected = os.environ["PKG_VERSION"]
+          assert "site-packages" in darktable_mcp.__file__, (
+              f"imported the source tree, not the installed wheel: {darktable_mcp.__file__}"
+          )
+          assert darktable_mcp.__version__ == expected, (
+              f"__version__ is {darktable_mcp.__version__!r}, expected {expected!r}"
+          )
+          dist_version = importlib.metadata.version("darktable-mcp")
+          assert dist_version == expected, (
+              f"dist metadata version is {dist_version!r}, expected {expected!r}; "
+              "the dynamic version wiring in pyproject.toml is broken"
+          )
+
+          lua = importlib.resources.files("darktable_mcp").joinpath("lua/darktable_mcp.lua")
+          assert lua.is_file(), f"packaged Lua plugin missing from the wheel at {lua}"
+          assert len(lua.read_bytes()) > 0, "packaged Lua plugin is empty"
+
+          # The exact call `darktable-mcp install-plugin` makes.
+          from darktable_mcp.cli.install_plugin import _packaged_lua_bytes
+
+          assert len(_packaged_lua_bytes()) > 0
+          print(f"installed wheel OK: version {expected}, Lua plugin {len(lua.read_bytes())} bytes")
+          PY
+
+          # Console script: entry point resolves, and the subcommand every user
+          # runs first actually writes the plugin out of the installed package.
+          "$VENV/bin/darktable-mcp" --help
+          "$VENV/bin/darktable-mcp" install-plugin --help
+          HOME="$FAKE_HOME" "$VENV/bin/darktable-mcp" install-plugin
+          test -s "$FAKE_HOME/.config/darktable/lua/darktable_mcp.lua"
+          grep -qx 'require "darktable_mcp"' "$FAKE_HOME/.config/darktable/luarc"
+          HOME="$FAKE_HOME" "$VENV/bin/darktable-mcp" uninstall-plugin
+          test ! -e "$FAKE_HOME/.config/darktable/lua/darktable_mcp.lua"
+          echo "console script OK"
+
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+          retention-days: 30
+
+  # ---------------------------------------------------------------------------
+  # Rehearsal upload. Manual dispatch only, opt-in via the input, and it can
+  # never run on a tag push -- so it can never be mistaken for the real thing.
+  # ---------------------------------------------------------------------------
+  publish-testpypi:
+    name: publish to TestPyPI (rehearsal)
+    if: github.event_name == 'workflow_dispatch' && inputs.publish-testpypi
+    needs: [build]
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/darktable-mcp
+    permissions:
+      id-token: write   # OIDC token for Trusted Publishing; no API token needed
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          # A second rehearsal of the same version is normal and should not go
+          # red just because TestPyPI already holds that file. This flag is
+          # deliberately NOT set on the real publish below.
+          skip-existing: true
+
+  # ---------------------------------------------------------------------------
+  # The real release. Tag pushes only.
+  # ---------------------------------------------------------------------------
+  publish-pypi:
+    name: publish to PyPI
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    needs: [build]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/darktable-mcp
+    permissions:
+      id-token: write   # OIDC token for Trusted Publishing; no API token needed
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        # No skip-existing: re-tagging a version already on PyPI is a mistake,
+        # and it must go red rather than report a silent success.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,16 @@
+# setuptools' sdist defaults pick up `tests/test_*.py` and nothing else under
+# tests/, so the sdist shipped without `tests/__init__.py` and without
+# `tests/lua/test_dispatcher.lua` — the Lua half of the dispatcher suite. The
+# published sdist could not run its own tests: `lua: cannot open
+# tests/lua/test_dispatcher.lua`. Extra sdist files are not expressible in
+# pyproject.toml, so they live here.
+graft tests
+
+# Belt and braces with [tool.setuptools.package-data]: the plugin must be in
+# the wheel or `darktable-mcp install-plugin`, the first thing every user runs,
+# fails on a fresh install.
+recursive-include darktable_mcp/lua *.lua
+
+global-exclude __pycache__ *.py[cod]
+prune .venv
+prune .github

--- a/README.md
+++ b/README.md
@@ -27,9 +27,13 @@ client; this server drives darktable.
   <destination>/.import.log
   ```
 
-  Camera filenames repeat across folders, across the two cards of a dual-slot body, and across *bodies* importing into the same destination — and the default destination `~/Pictures/import-YYYY-MM-DD/` is shared by every import on the same day. The old flat layout combined with `--skip-existing` silently dropped those duplicates. Import the destination recursively.
+  Camera filenames repeat across folders, across the two cards of a dual-slot body, and across *bodies* importing into the same destination — and the default destination `~/Pictures/import-YYYY-MM-DD/` is shared by every import on the same day. The old flat layout combined with gphoto2's `--skip-existing` silently dropped those duplicates; correctness no longer rests on that flag, which now only ever sees files the same run just wrote into its own private staging directory. Import the destination recursively.
 
-  The serial number is read once per camera via `gphoto2 --get-config serialnumber` and omitted when the camera doesn't report one. On the card-copy path a file that would collide with a *different* photo already on disk is written alongside it as `IMG_0001-2.CR3` and reported — never overwritten; sameness is judged on size plus the first and last 8 KB, and is only ever used to authorise a skip. **Known limit:** two bodies of the same model that report no serial cannot be distinguished, so give those separate destinations.
+  The serial number is read once per camera via `gphoto2 --get-config serialnumber` and omitted when the camera doesn't report one. On both paths a file that would collide with a *different* photo already on disk is written alongside it as `IMG_0001-2.CR3` and reported — never overwritten; sameness is judged on size plus the first and last 8 KB, and is only ever used to authorise a skip.
+
+  Two bodies of the same model that report no serial share a destination subdirectory, and **both bodies' photos are kept there**. The PTP path downloads into a private staging area and, before skipping files the destination appears to already hold, re-checks a bounded sample of them against the bytes on disk — a second body fails that check and its folder is fetched in full. Re-running stays cheap: a body with a serial transfers nothing it already delivered, and one without transfers at most 3 files per folder. Any file the card lists that doesn't reach the destination is reported by name.
+
+  **Residual limit:** that sample is bounded at 3 files per folder, so a second body whose sampled files are byte-identical to the first body's — in a folder holding more than 3 candidates — is still taken to be the same body. Folders with 3 or fewer candidates are checked exhaustively.
 
   `timeout_seconds` is an **overall budget for one camera**, shared across all its folders — not a per-folder timeout. Skipped files are counted and reported, and a post-flight shortfall (fewer files on disk than the camera said it held) is surfaced as a prominent `!! INCOMPLETE IMPORT` block, because that is the moment before someone formats the card.
 
@@ -121,7 +125,9 @@ No SQLite poking, no half-imported state, no GUI launch until step 3.
 - An MCP-compatible client (Claude Desktop, Claude Code, etc.)
 - Linux, or macOS for the parts that don't need `gphoto2`. The plugin installer writes to `~/.config/darktable/`, which is where darktable keeps its config on Linux and macOS but **not** on Windows — `import_from_camera` also needs `gphoto2`, which has no Windows build.
 
-The MCP SDK is pinned to `mcp>=1.9,<2`. mcp 2.0.0 removed the `@server.list_tools()` / `@server.call_tool()` decorators this server is built on; porting to the 2.x `MCPServer` API is open work.
+The MCP SDK is pinned to `mcp>=2,<3`. Tools are registered through the mcp 2.x low-level `Server(on_list_tools=…, on_call_tool=…)` handlers; the 1.x decorators this server used before do not exist in 2.x, so **mcp 1.x cannot run this code**.
+
+The low-level API is deliberate. The high-level `MCPServer` derives each `inputSchema` from the handler signature, which cannot express `additionalProperties: {type: integer, minimum: -1, maximum: 5}` — the rating bounds on `apply_ratings_batch` silently disappear — and it injects a `title` into every property. The tool schemas here are handwritten and pinned by a golden-snapshot test, because their descriptions are what the calling model reads to decide behaviour.
 
 ## Contributing
 

--- a/darktable_mcp/bridge/client.py
+++ b/darktable_mcp/bridge/client.py
@@ -7,7 +7,7 @@ import os
 import time
 import uuid
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 #: How long to sleep between polls of the response file. Small enough that a
 #: fast plugin round-trip still feels instant, large enough not to spin a core.
@@ -30,7 +30,7 @@ DEFAULT_TIMEOUTS = {
 }
 
 
-def resolve_timeout(method: str, timeout: Optional[float] = None) -> float:
+def resolve_timeout(method: str, timeout: float | None = None) -> float:
     """Resolve the wait budget for one bridge call.
 
     Args:
@@ -86,7 +86,7 @@ class Bridge:
         self,
         method: str,
         params: dict[str, Any],
-        timeout: Optional[float] = None,
+        timeout: float | None = None,
     ) -> Any:
         """Send one request to the plugin and wait for its response.
 
@@ -109,8 +109,7 @@ class Bridge:
 
         if not self._plugin_path.is_file():
             raise BridgePluginNotInstalledError(
-                f"plugin not installed at {self._plugin_path}. "
-                "Run: darktable-mcp install-plugin"
+                f"plugin not installed at {self._plugin_path}. " "Run: darktable-mcp install-plugin"
             )
 
         self._cache_dir.mkdir(parents=True, exist_ok=True)
@@ -147,9 +146,7 @@ class Bridge:
                         resp_path.unlink(missing_ok=True)
 
                     if not isinstance(response, dict) or "id" not in response:
-                        raise BridgeProtocolError(
-                            f"response missing id field: {response!r}"
-                        )
+                        raise BridgeProtocolError(f"response missing id field: {response!r}")
                     if "error" in response:
                         raise BridgeError(str(response["error"]))
                     if "result" not in response:
@@ -160,8 +157,7 @@ class Bridge:
                 time.sleep(POLL_INTERVAL_SECONDS)
 
             raise BridgeTimeoutError(
-                f"method {method!r} got no plugin response within its "
-                f"{timeout:g}s timeout"
+                f"method {method!r} got no plugin response within its " f"{timeout:g}s timeout"
             )
         finally:
             # Best-effort cleanup of our own request file.

--- a/darktable_mcp/cli/install_plugin.py
+++ b/darktable_mcp/cli/install_plugin.py
@@ -22,11 +22,7 @@ def _luarc_path(home: Path) -> Path:
 
 
 def _packaged_lua_bytes() -> bytes:
-    return (
-        importlib.resources.files("darktable_mcp")
-        .joinpath("lua/darktable_mcp.lua")
-        .read_bytes()
-    )
+    return importlib.resources.files("darktable_mcp").joinpath("lua/darktable_mcp.lua").read_bytes()
 
 
 def _is_active_require_line(line: str) -> bool:
@@ -51,9 +47,7 @@ def install(home: Path) -> None:
         text = luarc.read_text(encoding="utf-8")
     else:
         text = ""
-    already_active = any(
-        _is_active_require_line(ln) for ln in text.splitlines()
-    )
+    already_active = any(_is_active_require_line(ln) for ln in text.splitlines())
     if not already_active:
         if text and not text.endswith("\n"):
             text += "\n"

--- a/darktable_mcp/darktable/cli_wrapper.py
+++ b/darktable_mcp/darktable/cli_wrapper.py
@@ -9,7 +9,6 @@ import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional
 
 from ..utils.errors import DarktableNotFoundError, ExportError
 
@@ -64,9 +63,9 @@ class ExportResult:
     """Outcome of exporting one file."""
 
     input: str
-    output: Optional[str]
+    output: str | None
     ok: bool
-    error: Optional[str]
+    error: str | None
 
 
 class CLIWrapper:
@@ -87,8 +86,8 @@ class CLIWrapper:
 
     def __init__(
         self,
-        darktable_cli_path: Optional[str] = None,
-        configdir: Optional[Path] = None,
+        darktable_cli_path: str | None = None,
+        configdir: Path | None = None,
     ):
         """Initialize the CLI wrapper.
 
@@ -218,8 +217,8 @@ class CLIWrapper:
         output_path: Path,
         format_type: str = "jpeg",
         quality: int = 95,
-        max_width: Optional[int] = None,
-        max_height: Optional[int] = None,
+        max_width: int | None = None,
+        max_height: int | None = None,
         timeout: int = EXPORT_TIMEOUT_DEFAULT,
     ) -> Path:
         """Export an image using darktable-cli.
@@ -325,10 +324,10 @@ class CLIWrapper:
 
     @staticmethod
     def _plan_output_paths(
-        input_files: List[Path],
+        input_files: list[Path],
         output_dir: Path,
         format_type: str,
-    ) -> List[Path]:
+    ) -> list[Path]:
         """Assign one distinct output path per input, in input order.
 
         Two inputs from different source folders can share a stem
@@ -347,7 +346,7 @@ class CLIWrapper:
         """
         ext = _output_extension(format_type)
         taken = set()
-        planned: List[Path] = []
+        planned: list[Path] = []
 
         for input_file in input_files:
             stem = input_file.stem
@@ -370,15 +369,15 @@ class CLIWrapper:
 
     def batch_export(
         self,
-        input_files: List[Path],
+        input_files: list[Path],
         output_dir: Path,
         format_type: str = "jpeg",
         quality: int = 95,
-        max_width: Optional[int] = None,
-        max_height: Optional[int] = None,
-        max_workers: Optional[int] = None,
+        max_width: int | None = None,
+        max_height: int | None = None,
+        max_workers: int | None = None,
         timeout: int = EXPORT_TIMEOUT_DEFAULT,
-    ) -> List[ExportResult]:
+    ) -> list[ExportResult]:
         """Export multiple images in batch, in parallel.
 
         Each export boots a full darktable core, so the work is
@@ -414,7 +413,7 @@ class CLIWrapper:
         planned = self._plan_output_paths(input_files, output_dir, format_type)
 
         workers = max_workers if max_workers and max_workers > 0 else min(4, os.cpu_count() or 1)
-        results: List[Optional[ExportResult]] = [None] * len(input_files)
+        results: list[ExportResult | None] = [None] * len(input_files)
 
         with ThreadPoolExecutor(max_workers=workers) as pool:
             futures = {
@@ -443,8 +442,8 @@ class CLIWrapper:
         output_file: Path,
         format_type: str,
         quality: int,
-        max_width: Optional[int] = None,
-        max_height: Optional[int] = None,
+        max_width: int | None = None,
+        max_height: int | None = None,
         timeout: int = EXPORT_TIMEOUT_DEFAULT,
     ) -> ExportResult:
         """Export a single file, converting any failure into an ExportResult.

--- a/darktable_mcp/server.py
+++ b/darktable_mcp/server.py
@@ -4,8 +4,9 @@ import asyncio
 import functools
 import json
 import logging
+from collections.abc import Awaitable, Callable
 from pathlib import Path
-from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
+from typing import Any
 
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
@@ -32,7 +33,7 @@ from .utils.errors import DarktableMCPError
 
 logger = logging.getLogger(__name__)
 
-ToolHandler = Callable[[Dict[str, Any]], Awaitable[List[TextContent]]]
+ToolHandler = Callable[[dict[str, Any]], Awaitable[list[TextContent]]]
 
 
 class DarktableMCPServer:
@@ -40,10 +41,10 @@ class DarktableMCPServer:
 
     def __init__(self) -> None:
         self.app: Server = Server("darktable-mcp")
-        self._cli: Optional[CLIWrapper] = None
+        self._cli: CLIWrapper | None = None
         self.camera_tools = CameraTools()
         self.bridge = Bridge()
-        self._handler_map: Dict[str, ToolHandler] = self._build_handlers()
+        self._handler_map: dict[str, ToolHandler] = self._build_handlers()
         self._setup_tools()
 
     @property
@@ -55,11 +56,11 @@ class DarktableMCPServer:
 
     def _setup_tools(self) -> None:
         @self.app.list_tools()
-        async def list_tools() -> List[Tool]:
+        async def list_tools() -> list[Tool]:
             return self._tool_definitions()
 
         @self.app.call_tool()
-        async def call_tool(name: str, arguments: Dict[str, Any]) -> List[TextContent]:
+        async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
             handler = self._handler_map.get(name)
             if handler is None:
                 return [TextContent(type="text", text=f"Unknown tool: {name}")]
@@ -72,7 +73,7 @@ class DarktableMCPServer:
                 logger.exception("Tool %s crashed", name)
                 return [TextContent(type="text", text=f"Tool {name} crashed: {e}")]
 
-    def _tool_definitions(self) -> List[Tool]:
+    def _tool_definitions(self) -> list[Tool]:
         return [
             Tool(
                 name="view_photos",
@@ -283,8 +284,7 @@ class DarktableMCPServer:
                         "output_dir": {
                             "type": "string",
                             "description": (
-                                "Where to write JPEGs. "
-                                "Default: <source_dir>/.previews/"
+                                "Where to write JPEGs. " "Default: <source_dir>/.previews/"
                             ),
                         },
                         "max_dim": {
@@ -402,8 +402,7 @@ class DarktableMCPServer:
                             "minimum": -1,
                             "maximum": 5,
                             "description": (
-                                "Filter to exactly this rating "
-                                "(-1=reject, 0=unrated, 1-5=stars)"
+                                "Filter to exactly this rating " "(-1=reject, 0=unrated, 1-5=stars)"
                             ),
                         },
                         "rating_min": {
@@ -479,7 +478,7 @@ class DarktableMCPServer:
             ),
         ]
 
-    def _build_handlers(self) -> Dict[str, ToolHandler]:
+    def _build_handlers(self) -> dict[str, ToolHandler]:
         return {
             "import_from_camera": self._handle_import_from_camera,
             "export_images": self._handle_export_images,
@@ -493,13 +492,13 @@ class DarktableMCPServer:
             "apply_preset": self._handle_apply_preset,
         }
 
-    def list_tools(self) -> List[str]:
+    def list_tools(self) -> list[str]:
         """Tool names registered with the server (used by tests/introspection)."""
         return list(self._handler_map.keys())
 
     async def _bridge_call(
-        self, method: str, arguments: Dict[str, Any]
-    ) -> Tuple[Optional[Any], Optional[List[TextContent]]]:
+        self, method: str, arguments: dict[str, Any]
+    ) -> tuple[Any | None, list[TextContent] | None]:
         """Run one bridge call off the event loop and map its errors to text.
 
         This is the single home of the bridge error-to-message mapping; the
@@ -517,27 +516,31 @@ class DarktableMCPServer:
         try:
             result = await asyncio.to_thread(self.bridge.call, method, arguments)
         except BridgePluginNotInstalledError:
-            return None, [TextContent(
-                type="text",
-                text="darktable-mcp plugin not installed. Run: darktable-mcp install-plugin",
-            )]
+            return None, [
+                TextContent(
+                    type="text",
+                    text="darktable-mcp plugin not installed. Run: darktable-mcp install-plugin",
+                )
+            ]
         except BridgeTimeoutError:
             seconds = resolve_timeout(method)
-            return None, [TextContent(
-                type="text",
-                text=(
-                    f"{method} exceeded its {seconds:g}s bridge timeout. Either "
-                    "darktable is not running with the darktable-mcp Lua plugin "
-                    "loaded (open darktable and try again), or the library is "
-                    f"large enough that this call needs longer than {seconds:g}s "
-                    "to finish."
-                ),
-            )]
+            return None, [
+                TextContent(
+                    type="text",
+                    text=(
+                        f"{method} exceeded its {seconds:g}s bridge timeout. Either "
+                        "darktable is not running with the darktable-mcp Lua plugin "
+                        "loaded (open darktable and try again), or the library is "
+                        f"large enough that this call needs longer than {seconds:g}s "
+                        "to finish."
+                    ),
+                )
+            ]
         except BridgeError as e:
             return None, [TextContent(type="text", text=f"Plugin error: {e}")]
         return result, None
 
-    async def _handle_import_from_camera(self, arguments: Dict[str, Any]) -> List[TextContent]:
+    async def _handle_import_from_camera(self, arguments: dict[str, Any]) -> list[TextContent]:
         try:
             # Card transfers run for minutes to an hour; off the loop so the
             # stdio connection keeps serving other requests meanwhile.
@@ -547,7 +550,7 @@ class DarktableMCPServer:
             logger.error("import_from_camera failed: %s", e)
             return [TextContent(type="text", text=f"Error: {e}")]
 
-    async def _handle_export_images(self, arguments: Dict[str, Any]) -> List[TextContent]:
+    async def _handle_export_images(self, arguments: dict[str, Any]) -> list[TextContent]:
         photo_ids = arguments.get("photo_ids") or []
         output_path = arguments.get("output_path")
         format_type = arguments.get("format", "jpeg")
@@ -571,7 +574,7 @@ class DarktableMCPServer:
         out_dir = Path(output_path)
         # darktable-cli runs one subprocess per file, so a batch is minutes of
         # blocking work. Offload it and keep the event loop responsive.
-        results: List[ExportResult] = await asyncio.to_thread(
+        results: list[ExportResult] = await asyncio.to_thread(
             functools.partial(
                 self.cli.batch_export,
                 input_files=input_files,
@@ -589,7 +592,7 @@ class DarktableMCPServer:
         side_file = out_dir / ".export_images.jsonl"
         out_dir.mkdir(parents=True, exist_ok=True)
         ok = fail = 0
-        first_error: Optional[str] = None
+        first_error: str | None = None
         with side_file.open("w") as fh:
             for r in results:
                 # `r.ok` is the authority. The old code sniffed the status
@@ -621,7 +624,7 @@ class DarktableMCPServer:
             summary.append(f"first error: {first_error}")
         return [TextContent(type="text", text="\n".join(summary))]
 
-    async def _handle_extract_previews(self, arguments: Dict[str, Any]) -> List[TextContent]:
+    async def _handle_extract_previews(self, arguments: dict[str, Any]) -> list[TextContent]:
         source_dir = arguments.get("source_dir")
         if not source_dir:
             return [TextContent(type="text", text="source_dir is required")]
@@ -643,7 +646,7 @@ class DarktableMCPServer:
         )
         return [TextContent(type="text", text=format_extract_summary(result))]
 
-    async def _handle_open_in_darktable(self, arguments: Dict[str, Any]) -> List[TextContent]:
+    async def _handle_open_in_darktable(self, arguments: dict[str, Any]) -> list[TextContent]:
         source_dir = arguments.get("source_dir")
         if not source_dir:
             return [TextContent(type="text", text="source_dir is required")]
@@ -659,7 +662,7 @@ class DarktableMCPServer:
         )
         return [TextContent(type="text", text=format_open_summary(result))]
 
-    async def _handle_view_photos(self, arguments: Dict[str, Any]) -> List[TextContent]:
+    async def _handle_view_photos(self, arguments: dict[str, Any]) -> list[TextContent]:
         photos, error = await self._bridge_call("view_photos", arguments)
         if error is not None:
             return error
@@ -677,18 +680,20 @@ class DarktableMCPServer:
             lines.append(f"ID: {p['id']} | {p['filename']} | Rating: {stars} | {path}")
         return [TextContent(type="text", text="\n".join(lines))]
 
-    async def _handle_rate_photos(self, arguments: Dict[str, Any]) -> List[TextContent]:
+    async def _handle_rate_photos(self, arguments: dict[str, Any]) -> list[TextContent]:
         result, error = await self._bridge_call("rate_photos", arguments)
         if error is not None:
             return error
 
         updated = result.get("updated", 0)
-        return [TextContent(
-            type="text",
-            text=f"Updated {updated} photos with {arguments.get('rating')} stars",
-        )]
+        return [
+            TextContent(
+                type="text",
+                text=f"Updated {updated} photos with {arguments.get('rating')} stars",
+            )
+        ]
 
-    async def _handle_import_batch(self, arguments: Dict[str, Any]) -> List[TextContent]:
+    async def _handle_import_batch(self, arguments: dict[str, Any]) -> list[TextContent]:
         result, error = await self._bridge_call("import_batch", arguments)
         if error is not None:
             return error
@@ -709,7 +714,7 @@ class DarktableMCPServer:
             lines.append(result["note"])
         return [TextContent(type="text", text="\n".join(lines))]
 
-    async def _handle_list_styles(self, arguments: Dict[str, Any]) -> List[TextContent]:
+    async def _handle_list_styles(self, arguments: dict[str, Any]) -> list[TextContent]:
         result, error = await self._bridge_call("list_styles", arguments)
         if error is not None:
             return error
@@ -730,7 +735,7 @@ class DarktableMCPServer:
             lines.append(f"  ... and {count - 50} more (full list available; this is the first 50)")
         return [TextContent(type="text", text="\n".join(lines))]
 
-    async def _handle_apply_preset(self, arguments: Dict[str, Any]) -> List[TextContent]:
+    async def _handle_apply_preset(self, arguments: dict[str, Any]) -> list[TextContent]:
         result, error = await self._bridge_call("apply_preset", arguments)
         if error is not None:
             return error
@@ -743,7 +748,7 @@ class DarktableMCPServer:
             parts.append(f"Missed (image not in library): {', '.join(missed)}")
         return [TextContent(type="text", text="\n".join(parts))]
 
-    async def _handle_apply_ratings_batch(self, arguments: Dict[str, Any]) -> List[TextContent]:
+    async def _handle_apply_ratings_batch(self, arguments: dict[str, Any]) -> list[TextContent]:
         source_dir = arguments.get("source_dir")
         ratings = arguments.get("ratings") or {}
         if not source_dir:

--- a/darktable_mcp/server.py
+++ b/darktable_mcp/server.py
@@ -8,9 +8,16 @@ from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import Any
 
-from mcp.server import Server
+from mcp.server import Server, ServerRequestContext
 from mcp.server.stdio import stdio_server
-from mcp.types import TextContent, Tool
+from mcp.types import (
+    CallToolRequestParams,
+    CallToolResult,
+    ListToolsResult,
+    PaginatedRequestParams,
+    TextContent,
+    Tool,
+)
 
 from .bridge.client import (
     Bridge,
@@ -40,12 +47,23 @@ class DarktableMCPServer:
     """MCP server for darktable photo management and editing."""
 
     def __init__(self) -> None:
-        self.app: Server = Server("darktable-mcp")
+        # mcp 2.x removed the @server.list_tools() / @server.call_tool()
+        # decorators; the low-level Server now takes the same two handlers as
+        # constructor kwargs, dispatched by method string. The handcrafted
+        # `Tool` list below is why this stays on the low-level surface rather
+        # than moving to MCPServer: MCPServer derives each inputSchema from the
+        # handler's signature, which injects pydantic `title` keys and cannot
+        # express the `ratings` map's per-value `minimum`/`maximum`, so the
+        # agent-facing contract would drift.
+        self.app: Server[Any] = Server(
+            "darktable-mcp",
+            on_list_tools=self._on_list_tools,
+            on_call_tool=self._on_call_tool,
+        )
         self._cli: CLIWrapper | None = None
         self.camera_tools = CameraTools()
         self.bridge = Bridge()
         self._handler_map: dict[str, ToolHandler] = self._build_handlers()
-        self._setup_tools()
 
     @property
     def cli(self) -> CLIWrapper:
@@ -54,24 +72,43 @@ class DarktableMCPServer:
             self._cli = CLIWrapper()
         return self._cli
 
-    def _setup_tools(self) -> None:
-        @self.app.list_tools()
-        async def list_tools() -> list[Tool]:
-            return self._tool_definitions()
+    async def _on_list_tools(
+        self,
+        ctx: ServerRequestContext[Any],
+        params: PaginatedRequestParams | None,
+    ) -> ListToolsResult:
+        """Serve `tools/list`. The whole catalogue fits one page, so no cursor."""
+        return ListToolsResult(tools=self._tool_definitions())
 
-        @self.app.call_tool()
-        async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
-            handler = self._handler_map.get(name)
-            if handler is None:
-                return [TextContent(type="text", text=f"Unknown tool: {name}")]
-            try:
-                return await handler(arguments)
-            except DarktableMCPError as e:
-                logger.error("Tool %s failed: %s", name, e)
-                return [TextContent(type="text", text=f"Error: {e}")]
-            except Exception as e:
-                logger.exception("Tool %s crashed", name)
-                return [TextContent(type="text", text=f"Tool {name} crashed: {e}")]
+    async def _on_call_tool(
+        self,
+        ctx: ServerRequestContext[Any],
+        params: CallToolRequestParams,
+    ) -> CallToolResult:
+        """Serve `tools/call`.
+
+        Every outcome — unknown tool, DarktableMCPError, unexpected crash —
+        comes back as ordinary text content with the default ``isError=False``,
+        exactly as the 1.x decorator produced. open_in_darktable depends on
+        this: a raised DarktableMCPError must reach the agent as tool output it
+        can read and act on, not as a JSON-RPC transport error.
+        """
+        return CallToolResult(
+            content=list(await self._call_tool(params.name, params.arguments or {}))
+        )
+
+    async def _call_tool(self, name: str, arguments: dict[str, Any]) -> list[TextContent]:
+        handler = self._handler_map.get(name)
+        if handler is None:
+            return [TextContent(type="text", text=f"Unknown tool: {name}")]
+        try:
+            return await handler(arguments)
+        except DarktableMCPError as e:
+            logger.error("Tool %s failed: %s", name, e)
+            return [TextContent(type="text", text=f"Error: {e}")]
+        except Exception as e:
+            logger.exception("Tool %s crashed", name)
+            return [TextContent(type="text", text=f"Tool {name} crashed: {e}")]
 
     def _tool_definitions(self) -> list[Tool]:
         return [
@@ -85,7 +122,7 @@ class DarktableMCPServer:
                     "Requires darktable to be running with the darktable-mcp "
                     "Lua plugin installed (see darktable-mcp install-plugin)."
                 ),
-                inputSchema={
+                input_schema={
                     "type": "object",
                     "properties": {
                         "filter": {
@@ -115,7 +152,7 @@ class DarktableMCPServer:
                     "darktable library. Requires darktable to be running with "
                     "the darktable-mcp Lua plugin installed."
                 ),
-                inputSchema={
+                input_schema={
                     "type": "object",
                     "properties": {
                         "photo_ids": {
@@ -143,7 +180,7 @@ class DarktableMCPServer:
                     "darktable to be running with the darktable-mcp Lua plugin "
                     "installed."
                 ),
-                inputSchema={
+                input_schema={
                     "type": "object",
                     "properties": {
                         "source_path": {
@@ -168,7 +205,7 @@ class DarktableMCPServer:
                     "must match exactly. Requires darktable to be running with the "
                     "darktable-mcp Lua plugin installed."
                 ),
-                inputSchema={
+                input_schema={
                     "type": "object",
                     "properties": {},
                 },
@@ -182,7 +219,7 @@ class DarktableMCPServer:
                     "darktable to be running with the darktable-mcp Lua plugin "
                     "installed."
                 ),
-                inputSchema={
+                input_schema={
                     "type": "object",
                     "properties": {
                         "photo_ids": {
@@ -216,9 +253,15 @@ class DarktableMCPServer:
                     "same destination. Import the destination recursively. "
                     "A file that would collide with a different photo already "
                     "on disk is kept alongside it as <name>-2.<ext>, never "
-                    "overwritten. Two bodies of the SAME model that report no "
-                    "serial number cannot be told apart — give those separate "
-                    "destinations. "
+                    "overwritten. This holds for two bodies of the same model "
+                    "that report no serial number and therefore share a "
+                    "subdirectory: before skipping files a destination appears "
+                    "to already hold, such a camera is asked for a small "
+                    "sample of them and the bytes are compared, so a second "
+                    "body's photos are kept rather than dropped. Re-running is "
+                    "cheap: a body with a serial number transfers nothing it "
+                    "already delivered. Any file the card lists that does not "
+                    "reach the destination is reported by name. "
                     "Cost: this tool runs to completion synchronously and does "
                     "not return early. A full card can take many minutes, up to "
                     "the 1 hour default timeout, which is longer than most MCP "
@@ -226,7 +269,7 @@ class DarktableMCPServer:
                     "while it runs by tailing the .import.log file in the "
                     "destination directory."
                 ),
-                inputSchema={
+                input_schema={
                     "type": "object",
                     "properties": {
                         "destination": {
@@ -274,7 +317,7 @@ class DarktableMCPServer:
                     "path from each item rather than assuming "
                     "<output_dir>/<stem>.jpg."
                 ),
-                inputSchema={
+                input_schema={
                     "type": "object",
                     "properties": {
                         "source_dir": {
@@ -335,7 +378,7 @@ class DarktableMCPServer:
                     "A sidecar with no recognisable rating is skipped with an "
                     "error rather than overwritten."
                 ),
-                inputSchema={
+                input_schema={
                     "type": "object",
                     "properties": {
                         "source_dir": {
@@ -390,7 +433,7 @@ class DarktableMCPServer:
                     "`rating_max=N` (<=), arbitrary `rating_min..rating_max` "
                     "inner ranges, or no filter at all."
                 ),
-                inputSchema={
+                input_schema={
                     "type": "object",
                     "properties": {
                         "source_dir": {
@@ -438,7 +481,7 @@ class DarktableMCPServer:
                     "written file is <stem>.<format>. Read the real path from "
                     "the `output` field of the .export_images.jsonl side file."
                 ),
-                inputSchema={
+                input_schema={
                     "type": "object",
                     "properties": {
                         "photo_ids": {

--- a/darktable_mcp/tools/camera_tools.py
+++ b/darktable_mcp/tools/camera_tools.py
@@ -8,9 +8,10 @@ import shutil
 import subprocess
 import threading
 import time
+import uuid
 from datetime import date, datetime
 from pathlib import Path
-from typing import Any, TextIO
+from typing import Any, NamedTuple, TextIO
 
 from ..utils.errors import DarktableMCPError
 
@@ -21,6 +22,53 @@ _MODEL_WORD_RE = re.compile(r"[A-Za-z0-9]{4,}")
 _TAG_UNSAFE_RE = re.compile(r"[^A-Za-z0-9._-]+")
 #: `gphoto2 --get-config serialnumber` prints a `Current: <value>` line.
 _SERIAL_CURRENT_RE = re.compile(r"^Current:\s*(.+?)\s*$", re.MULTILINE)
+#: A serial number is the only thing that makes an identity unique to one
+#: body, and `_camera_identity` spells it `sn_<serial>`. Lower-case on
+#: purpose: a model word like "SN" survives `_model_tag` upper-cased and
+#: must not be mistaken for a serial.
+_IDENTITY_SERIAL_RE = re.compile(r"(?:^|_)sn_[A-Za-z0-9]")
+#: `gphoto2 --list-files` prints one `#<n> <name> <perms> <size> <mime>` line
+#: per file. The name is separated from the rest by 2+ spaces.
+_LIST_FILE_LINE_RE = re.compile(r"^#(\d+)\s+(\S.*?)\s{2,}(.*)$")
+#: First number in the remainder of such a line, with gphoto2's unit suffix.
+#: Real gphoto2 prints KB; older/other builds print raw bytes, so the unit is
+#: optional and "no unit" means bytes.
+_LIST_SIZE_RE = re.compile(r"(\d+)\s*(KB|MB|GB|B)?(?:\s|$)")
+#: gphoto2 announces each file it writes. The path is needed to identify the
+#: one that was in flight when a transfer timed out — that file is truncated.
+_SAVING_AS_RE = re.compile(r"Saving file as\s+(.+?)\s*$")
+
+
+class _CameraFile(NamedTuple):
+    """One entry of `gphoto2 --list-files` for a single camera folder.
+
+    `number` is gphoto2's own 1-based file number within the folder, which
+    is what `--get-file` takes. Not `index`: that name is already a tuple
+    method, and shadowing it on a NamedTuple is a trap. `size_kb` is None when the line carried no
+    parseable size — treated everywhere as "unknown", never as "zero".
+    """
+
+    number: int
+    name: str
+    size_kb: int | None
+
+
+class _FetchResult(NamedTuple):
+    """Outcome of one `gphoto2 --get-*` invocation into the staging area.
+
+    `timeout` is carried rather than raised so the caller can still place
+    the files that did arrive — a timeout that threw away a half-finished
+    transfer would make a card too big for the budget impossible to import
+    at all, however many times it is retried.
+    """
+
+    saved: int
+    skipped: int
+    errors: list[str]
+    last_saved: str | None
+    timeout: subprocess.TimeoutExpired | None
+
+
 #: Words that carry no device identity. gphoto2 calls every USB-Mass-Storage
 #: mount "Mass Storage Camera", so a model made only of these contributes
 #: nothing to a destination tag and is dropped rather than baked in.
@@ -41,28 +89,79 @@ class CameraTools:
     the newcomer vanish — gphoto2's `--skip-existing` and the MSC size
     compare both read it as "already copied" — which is silent data loss.
 
-    Two things prevent that now:
+    Three things prevent that now:
 
     1. The destination tag carries the camera's identity: a sanitised model
        plus, when the body reports one, its serial number. The tag is
        derived only from things that are stable across unplug/replug (never
        from the gphoto2 port, which is reassigned), so re-running into the
        same destination is still a cheap idempotent resume.
-    2. On the MSC path, an existing destination file is only ever treated as
-       "already copied" when it still looks like the same file. Anything
-       else is written under a distinct name; nothing is overwritten.
+    2. On *both* paths, an existing destination file is only ever treated as
+       "already copied" when it still looks like the same file — equal size
+       and equal first/last 8 KB. Anything else is written under a distinct
+       `-2` name and reported; nothing is overwritten, nothing is dropped.
+    3. Nothing is written straight into the destination any more. The PTP
+       path downloads into a private per-run staging directory that cannot
+       collide with anything, and every file is then moved into place
+       through the same never-overwrite decision the MSC path uses. gphoto2's
+       `--skip-existing` is still passed, but it can only ever fire against
+       files this same run just downloaded into that private directory, so
+       it is no longer load-bearing for correctness.
 
-    What is still *not* guaranteed: two bodies of the same model that report
-    no serial number share a tag. On the MSC path point 2 keeps both files
-    regardless. On the PTP path gphoto2's own `--skip-existing` decides, and
-    it compares nothing but the path — see `_download_one_folder`.
+    Two bodies of the same model that report no serial number still share a
+    tag, and therefore a destination directory. That is now handled rather
+    than merely documented: before skipping files that a destination already
+    appears to hold, a weak-identity camera is asked for a small sample of
+    them and the bytes are compared (`_probe_body_identity`). A second body
+    fails that check, so all of its files are fetched and land beside the
+    first body's as `DSC_0001-2.NEF`.
+
+    What is still *not* guaranteed:
+
+    - The sample is bounded (`PROBE_SAMPLE_SIZE`). When a folder holds more
+      candidates than that, a second body whose sampled files happen to be
+      byte-identical to the first body's — same names, same sizes, same
+      content — is not detected, and its differing files in that folder are
+      skipped. When a folder holds no more candidates than the sample size,
+      the check is exhaustive and there is no hole.
+    - The cheap skip rests on the size `gphoto2 --list-files` reports
+      (kilobyte granularity, ±1 KB) plus the sample above. Content is not
+      compared for every file because on PTP reading one byte of a file
+      means downloading all of it.
+    - When `--list-files` cannot be read or parsed, the folder falls back to
+      a full `--get-all-files` pull into staging on every run. That is
+      correct — placement still compares content — but it is not a cheap
+      resume, and the reason is written to the progress log.
+    - Two cameras that report the *same* serial number (a firmware bug)
+      would both be trusted as unique and skip the sample check.
+    - Files are fetched by gphoto2's per-folder file number, which comes
+      from the listing. Shooting onto the card *during* an import can shift
+      those numbers, so the wrong subset gets fetched. Nothing is lost or
+      misfiled by it — each file still arrives under its own name and is
+      placed by content — but files that were missed are reported by name
+      (`_report_missing`) and need another run.
     """
 
     DOWNLOAD_TIMEOUT_DEFAULT = 3600
     LIST_FOLDERS_TIMEOUT = 30
+    LIST_FILES_TIMEOUT = 60
     NUM_FILES_TIMEOUT = 30
     SERIAL_TIMEOUT = 15
     PROGRESS_LOG_NAME = ".import.log"
+    #: Private per-run download area under the destination. Dot-prefixed so
+    #: darktable's own folder import ignores it, and excluded from every
+    #: file count this module makes.
+    STAGING_DIR_NAME = ".import-staging"
+    #: How many already-present-looking files a weak-identity camera is
+    #: asked to re-send so their bytes can be compared with what is already
+    #: in the destination. Small on purpose: this is the price of every
+    #: resume for a body with no serial number. Three is enough to catch a
+    #: different body while costing about one RAW file per folder, because
+    #: the sample is the smallest, the median and the largest candidate.
+    PROBE_SAMPLE_SIZE = 3
+    #: `--list-files` reports sizes in whole kilobytes, and different builds
+    #: round differently, so sizes within this many KB count as equal.
+    SIZE_TOLERANCE_KB = 1
     #: Subdirectory used when the camera folder tree could not be enumerated
     #: and a single recursive download from "/" is used instead.
     ROOT_FOLDER_TAG = "camera"
@@ -239,6 +338,112 @@ class CameraTools:
         return int(match.group(1)) if match else None
 
     @staticmethod
+    def _parse_size_kb(rest: str) -> int | None:
+        """Pull the file size out of the tail of a `--list-files` line.
+
+        Args:
+            rest: everything after the filename, e.g. "rd  9863 KB image/x-nikon-nef".
+
+        Returns:
+            Size in whole kilobytes, or None when the line carries no
+            parseable number. None means "unknown", and every caller treats
+            unknown as "cannot be used to authorise a skip on its own".
+        """
+        match = _LIST_SIZE_RE.search(rest)
+        if not match:
+            return None
+        value = int(match.group(1))
+        unit = match.group(2)
+        if unit == "KB":
+            return value
+        if unit == "MB":
+            return value * 1024
+        if unit == "GB":
+            return value * 1024 * 1024
+        return value // 1024
+
+    def _list_files_in_folder(
+        self, model: str, port: str, src_folder: str
+    ) -> list[_CameraFile] | None:
+        """Enumerate one camera folder's files with their sizes.
+
+        This is what replaced `--skip-existing` as the resume mechanism: it
+        lets us decide *ourselves*, before transferring anything, which
+        files the destination already holds — and, unlike gphoto2's
+        path-only compare, the decision can look at the size and (via
+        `_probe_body_identity`) at the bytes.
+
+        Deliberately total, like `_probe_serial`: every failure mode
+        degrades to None and the caller falls back to pulling the whole
+        folder into staging, which is slower but still cannot lose a file.
+
+        Returns:
+            One `_CameraFile` per line parsed, in gphoto2's own order, or
+            None when the listing could not be obtained or yielded nothing.
+        """
+        env = {**os.environ, "LC_ALL": "C", "LANG": "C"}
+        try:
+            result = subprocess.run(
+                [
+                    "gphoto2",
+                    "--camera",
+                    model,
+                    "--port",
+                    port,
+                    "--folder",
+                    src_folder,
+                    "--list-files",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=self.LIST_FILES_TIMEOUT,
+                env=env,
+            )
+        except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+            return None
+
+        if result.returncode != 0:
+            return None
+
+        entries: list[_CameraFile] = []
+        for line in result.stdout.splitlines():
+            match = _LIST_FILE_LINE_RE.match(line.rstrip())
+            if not match:
+                continue
+            entries.append(
+                _CameraFile(
+                    number=int(match.group(1)),
+                    name=match.group(2).strip(),
+                    size_kb=self._parse_size_kb(match.group(3)),
+                )
+            )
+        return entries or None
+
+    @staticmethod
+    def _range_expression(indices: list[int]) -> str:
+        """Collapse gphoto2 file numbers into its `--get-file` RANGE syntax.
+
+        Args:
+            indices: 1-based file numbers, any order.
+
+        Returns:
+            e.g. "1-3,7,9-10". Empty string for an empty selection.
+        """
+        ordered = sorted(set(indices))
+        if not ordered:
+            return ""
+        spans: list[str] = []
+        start = previous = ordered[0]
+        for value in ordered[1:]:
+            if value == previous + 1:
+                previous = value
+                continue
+            spans.append(str(start) if start == previous else f"{start}-{previous}")
+            start = previous = value
+        spans.append(str(start) if start == previous else f"{start}-{previous}")
+        return ",".join(spans)
+
+    @staticmethod
     def _model_tag(model: str) -> str:
         """Sanitise a camera model string into a tag fragment.
 
@@ -334,6 +539,25 @@ class CameraTools:
             parts.append(f"sn_{serial}")
         return "_".join(parts)
 
+    @staticmethod
+    def _identity_is_body_unique(identity: str) -> bool:
+        """Does this identity pick out one physical body, or just a model?
+
+        A serial number does; a model name does not — every other
+        `Nikon_D850` in the world resolves to the same tag, and two of them
+        imported into one destination share a directory. This is the switch
+        that decides whether an "already there" file may be skipped on the
+        strength of its name and size alone, or whether the camera has to
+        prove it with bytes first (`_probe_body_identity`).
+
+        Args:
+            identity: `_camera_identity` output.
+
+        Returns:
+            True only when the identity carries an `sn_<serial>` component.
+        """
+        return bool(_IDENTITY_SERIAL_RE.search(identity or ""))
+
     @classmethod
     def _folder_tag(cls, src_folder: str) -> str:
         """Turn a camera folder path into one filesystem-safe directory name.
@@ -384,82 +608,65 @@ class CameraTools:
         """Destination subdirectory that receives one camera folder's files."""
         return destination / cls._camera_folder_tag(identity, src_folder)
 
-    def _download_one_folder(
+    @staticmethod
+    def _write_log(progress_log: TextIO | None, text: str) -> None:
+        """Append one line to the progress log, if there is one."""
+        if progress_log is None:
+            return
+        progress_log.write(text if text.endswith("\n") else text + "\n")
+        progress_log.flush()
+
+    def _run_gphoto2_get(
         self,
         model: str,
         port: str,
         src_folder: str,
-        destination: Path,
+        selection: list[str],
+        filename_pattern: str,
         timeout_seconds: int,
         progress_log: TextIO | None = None,
         expected_total: int | None = None,
-        identity: str | None = None,
-    ) -> tuple[int, int, list[str]]:
-        """Run gphoto2 to copy all files in a single camera folder.
+        saved_offset: int = 0,
+    ) -> "_FetchResult":
+        """Run one gphoto2 transfer and stream its progress.
 
-        Files land in `<destination>/<identity>_<folder tag>/`, never
-        directly in `destination`: `%f` is the bare basename, so a shared
-        destination would make `100NCD80/DSC_0001.NEF` and
-        `101NCD80/DSC_0001.NEF` collide — and, because the folder path is
-        generic across bodies of the same generation, would do the same to
-        two different cameras imported into one destination.
-        `--skip-existing` would silently drop the newcomer in both cases.
+        `selection` is either `["--get-all-files"]` or
+        `["--get-file", "1-3,7"]`; everything else about the invocation is
+        identical, so both routes get the same locale pinning, the same
+        streamed progress and the same gvfs-lock diagnosis.
 
-        What `--skip-existing` does and does not guarantee: gphoto2 compares
-        *nothing but the target path*. It never looks at size or content. So
-        a skip is safe exactly to the extent that the path is unique to one
-        photo, which is what the `<identity>_<folder tag>` directory buys.
-        The residual hole is two bodies of the same model that both report
-        no serial number: they share an identity, and if both hold a
-        `DSC_0001.NEF` in the same folder path the second one is skipped
-        with no error. Nothing on the PTP path can detect that — gphoto2
-        makes the decision inside its own process, and the post-flight
-        count sees a full destination. Import such bodies into separate
-        destinations. (The MSC path has no such hole; see
-        `_download_from_msc`, which never trusts a path alone.)
+        `--skip-existing` is still passed, but `filename_pattern` always
+        points into a private per-run staging directory, so it can only
+        fire against a file this same run just wrote there. It is a guard
+        against gphoto2 stopping to ask "overwrite?" on stdin, not a
+        correctness mechanism — correctness is `_place_staged_files`.
 
         Streams stdout via Popen + reader threads so per-file progress is
         written to `progress_log` as the transfer happens (the user can
         `tail -f` the log file in another terminal). `--filename %f.%C`
         preserves the file extension.
 
-        When `src_folder` is "/" (folder enumeration failed, so this is one
-        recursive pull of the whole camera) `%F` — gphoto2's own camera
-        folder path — is inserted as well, so the recursion still cannot
-        flatten two folders onto each other.
-
         Args:
             model: gphoto2 model string.
             port: gphoto2 port string.
-            src_folder: camera folder to pull.
-            destination: import root; the per-folder subdirectory is
-                created underneath it.
-            timeout_seconds: subprocess timeout for this folder.
-            progress_log: open text file handle to receive timestamped
-                "Saving file as ..." lines. None to disable logging.
+            src_folder: camera folder to pull from.
+            selection: the "which files" flags, see above.
+            filename_pattern: gphoto2 `--filename` pattern, inside staging.
+            timeout_seconds: subprocess timeout for this transfer.
+            progress_log: open text file handle for progress lines.
             expected_total: if known, formats progress as "(N/total)".
-            identity: camera identity from `_camera_identity`, computed once
-                per camera by the caller so the serial probe is not repeated
-                per folder. None means "derive it from `model` alone", which
-                is the safe fallback for direct callers — never a bare
-                folder tag with no camera in it.
+            saved_offset: number already reported for this folder, so a
+                probe transfer followed by the main one keeps counting up.
 
         Returns:
-            Tuple of (files_saved, files_skipped, error_lines).
+            `_FetchResult`. A timeout is *returned*, not raised, so the
+            caller can still place the files that did arrive before it
+            propagates the failure.
 
         Raises:
             DarktableMCPError: gphoto2 missing or camera locked by another
                 process (gvfs etc.).
-            subprocess.TimeoutExpired: caller handles partial transfers.
         """
-        ident = identity if identity is not None else self._model_tag(model)
-        folder_dest = self._folder_dest(destination, src_folder, ident)
-        folder_dest.mkdir(parents=True, exist_ok=True)
-        if self._folder_tag(src_folder) == self.ROOT_FOLDER_TAG:
-            filename_pattern = f"{folder_dest}/%F/%f.%C"
-        else:
-            filename_pattern = f"{folder_dest}/%f.%C"
-
         cmd = [
             "gphoto2",
             "--camera",
@@ -468,7 +675,7 @@ class CameraTools:
             port,
             "--folder",
             src_folder,
-            "--get-all-files",
+            *selection,
             "--skip-existing",
             "--filename",
             filename_pattern,
@@ -491,6 +698,7 @@ class CameraTools:
 
         counters = {"saved": 0, "skipped": 0}
         stderr_buf: list[str] = []
+        last_saved: list[str] = []
 
         def _consume_stdout() -> None:
             stream = proc.stdout
@@ -500,12 +708,16 @@ class CameraTools:
                 for line in stream:
                     if "Saving file as" in line:
                         counters["saved"] += 1
+                        match = _SAVING_AS_RE.search(line)
+                        if match:
+                            last_saved.append(match.group(1))
                         if progress_log is not None:
                             ts = datetime.now().strftime("%H:%M:%S")
+                            done = saved_offset + counters["saved"]
                             if expected_total:
-                                prefix = f"[{ts}] ({counters['saved']}/{expected_total}) "
+                                prefix = f"[{ts}] ({done}/{expected_total}) "
                             else:
-                                prefix = f"[{ts}] ({counters['saved']}) "
+                                prefix = f"[{ts}] ({done}) "
                             progress_log.write(prefix + line.rstrip("\n") + "\n")
                             progress_log.flush()
                     elif "Skip existing" in line:
@@ -531,23 +743,25 @@ class CameraTools:
         t_out.start()
         t_err.start()
 
+        timeout_exc: subprocess.TimeoutExpired | None = None
         try:
             proc.wait(timeout=timeout_seconds)
-        except subprocess.TimeoutExpired:
+        except subprocess.TimeoutExpired as exc:
+            timeout_exc = exc
             proc.kill()
             t_out.join(timeout=2)
             t_err.join(timeout=2)
-            raise
 
-        t_out.join(timeout=5)
-        t_err.join(timeout=5)
+        if timeout_exc is None:
+            t_out.join(timeout=5)
+            t_err.join(timeout=5)
 
         saved = counters["saved"]
         skipped = counters["skipped"]
         returncode = proc.returncode if proc.returncode is not None else 0
 
         errors: list[str] = []
-        if returncode != 0:
+        if returncode != 0 and timeout_exc is None:
             errors.extend(line.rstrip() for line in stderr_buf if line.strip())
 
         stderr_lower = "".join(stderr_buf).lower()
@@ -564,7 +778,523 @@ class CameraTools:
                 "or stop gvfs-gphoto2-volume-monitor, then retry."
             )
 
-        return saved, skipped, errors
+        return _FetchResult(
+            saved=saved,
+            skipped=skipped,
+            errors=errors,
+            last_saved=last_saved[-1] if last_saved else None,
+            timeout=timeout_exc,
+        )
+
+    @classmethod
+    def _dest_twins(cls, folder_dest: Path, name: str) -> list[Path]:
+        """Every destination file that could already be a copy of `name`.
+
+        A previous run may have parked a same-named-but-different photo as
+        `DSC_0001-2.NEF`, so "is this file already here?" has to consider
+        the whole `-N` family, not just the camera's own name. Without that,
+        the second body would re-fetch its whole card on every resume and
+        grow a new `-3`, `-4`, ... each time.
+
+        The scan stops at the first gap because `_never_overwrite_target`
+        allocates the suffixes densely. A user who deletes `-2` but keeps
+        `-3` hides the latter from this check, which costs a redundant copy,
+        never a lost one.
+        """
+        twins: list[Path] = []
+        primary = folder_dest / name
+        if primary.exists():
+            twins.append(primary)
+        for index in range(2, cls.MAX_DISTINCT_SUFFIX + 1):
+            candidate = folder_dest / cls._distinct_name(name, index)
+            if not candidate.exists():
+                break
+            twins.append(candidate)
+        return twins
+
+    @classmethod
+    def _destination_holds(cls, folder_dest: Path, entry: _CameraFile) -> bool:
+        """Does the destination look like it already holds this card file?
+
+        "Looks like" is the honest word: this is a name plus a kilobyte-
+        granular size compare, which is all that can be known about a PTP
+        file without downloading it. It is only ever used to *propose* a
+        skip; for a camera whose identity is not unique to one body that
+        proposal still has to survive `_probe_body_identity`.
+        """
+        twins = cls._dest_twins(folder_dest, entry.name)
+        if not twins:
+            return False
+        if entry.size_kb is None:
+            # No size to compare: the name is all we have, which is exactly
+            # what gphoto2's --skip-existing used to decide on.
+            return True
+        for twin in twins:
+            try:
+                if abs(twin.stat().st_size // 1024 - entry.size_kb) <= cls.SIZE_TOLERANCE_KB:
+                    return True
+            except OSError:
+                continue
+        return False
+
+    @classmethod
+    def _probe_sample(cls, present: list[_CameraFile]) -> list[_CameraFile]:
+        """Pick the files a weak-identity camera must re-send to prove itself.
+
+        Smallest, median and largest by reported size: the smallest keeps
+        the check cheap, the largest and the median keep it from being
+        fooled by a folder full of identically-sized sidecars. Deterministic
+        so two runs of the same card probe the same files.
+        """
+        ordered = sorted(present, key=lambda e: (e.size_kb if e.size_kb is not None else 0, e.name))
+        if len(ordered) <= cls.PROBE_SAMPLE_SIZE:
+            return ordered
+        picks = {0, len(ordered) // 2, len(ordered) - 1}
+        return [ordered[i] for i in sorted(picks)]
+
+    def _probe_body_identity(
+        self,
+        model: str,
+        port: str,
+        src_folder: str,
+        present: list[_CameraFile],
+        folder_dest: Path,
+        probe_dir: Path,
+        timeout_seconds: int,
+        progress_log: TextIO | None = None,
+    ) -> tuple[bool, dict[str, Path], list[str]]:
+        """Ask the camera to prove that the destination holds *its* photos.
+
+        This is the fix for the one hole the identity tag cannot close. Two
+        bodies of the same model that report no serial number resolve to the
+        same tag and therefore the same destination directory, and no name,
+        size, folder path or port can tell them apart — the port is
+        reassigned on every re-plug, and the collision usually happens
+        across two runs (two imports into the same
+        `~/Pictures/import-<today>/`), not within one. The only thing that
+        can distinguish them is the bytes, and on PTP getting the bytes
+        means downloading the file. So download a bounded sample of them.
+
+        Args:
+            model: gphoto2 model string.
+            port: gphoto2 port string.
+            src_folder: camera folder being imported.
+            present: the listed files the destination appears to hold.
+            folder_dest: destination subdirectory for this camera folder.
+            probe_dir: private directory the sample is fetched into.
+            timeout_seconds: budget for the sample transfer.
+            progress_log: progress log, for the verdict line.
+
+        Returns:
+            (verified, fetched, errors). `verified` True means every sampled
+            file matched something already in the destination, so the whole
+            `present` set may be skipped without transferring it. False
+            means at least one did not — the destination belongs to another
+            body (or holds truncated files), and the caller must fetch
+            everything. `fetched` maps filename to the already-downloaded
+            copy in `probe_dir` so the caller does not pay for it twice.
+        """
+        sample = self._probe_sample(present)
+        ranges = self._range_expression([entry.number for entry in sample])
+        probe_dir.mkdir(parents=True, exist_ok=True)
+        result = self._run_gphoto2_get(
+            model,
+            port,
+            src_folder,
+            ["--get-file", ranges],
+            f"{probe_dir}/%f.%C",
+            timeout_seconds,
+        )
+        fetched = {path.name: path for path in sorted(probe_dir.iterdir()) if path.is_file()}
+        errors = list(result.errors)
+
+        if not fetched:
+            self._write_log(
+                progress_log,
+                f"   !! could not re-read a sample of {src_folder} to confirm that "
+                f"{folder_dest.name}/ holds this camera's photos; fetching the "
+                f"whole folder instead so nothing can be skipped by mistake",
+            )
+            return False, {}, errors
+
+        unmatched = [
+            name
+            for name, staged in fetched.items()
+            if not any(
+                self._looks_like_same_file(staged, twin)
+                for twin in self._dest_twins(folder_dest, name)
+            )
+        ]
+        if unmatched:
+            self._write_log(
+                progress_log,
+                f"   ** {folder_dest.name}/ already holds different photos under "
+                f"these names ({', '.join(sorted(unmatched)[:3])}) — a second body of "
+                f"the same model with no serial number. Fetching the whole folder; "
+                f"nothing already there will be overwritten.",
+            )
+            return False, fetched, errors
+
+        self._write_log(
+            progress_log,
+            f"   confirmed by sample ({', '.join(sorted(fetched))}): "
+            f"{folder_dest.name}/ already holds this camera's copies of "
+            f"{len(present)} file(s)",
+        )
+        return True, fetched, errors
+
+    def _place_staged_files(
+        self,
+        stage_folder: Path,
+        folder_dest: Path,
+        progress_log: TextIO | None = None,
+    ) -> tuple[int, int, list[str], list[Path]]:
+        """Move a folder's downloaded files into the destination for keeps.
+
+        Every move goes through `_never_overwrite_target`, the same decision
+        the MSC path uses, so a name that is already taken by a *different*
+        photo yields `DSC_0001-2.NEF` instead of an overwrite or a silent
+        skip. Relative subdirectories are preserved, which matters for the
+        `/` fallback where gphoto2's `%F` recreates the camera's own tree.
+
+        Returns:
+            (placed, skipped, messages, unplaced). `skipped` counts files
+            the destination provably already had. `unplaced` are files that
+            could not be moved at all; they are deliberately left in staging
+            rather than discarded, and the caller reports where they are.
+        """
+        placed = 0
+        skipped = 0
+        messages: list[str] = []
+        unplaced: list[Path] = []
+        if not stage_folder.exists():
+            return placed, skipped, messages, unplaced
+
+        for staged in sorted(p for p in stage_folder.rglob("*") if p.is_file()):
+            relative = staged.relative_to(stage_folder)
+            target_dir = folder_dest / relative.parent
+            try:
+                target_dir.mkdir(parents=True, exist_ok=True)
+                target = self._never_overwrite_target(staged, target_dir)
+                if target is None:
+                    skipped += 1
+                    staged.unlink()
+                    continue
+                shutil.move(str(staged), str(target))
+                placed += 1
+                if target.name != staged.name:
+                    note = (
+                        f"{self.RENAMED_PREFIX} {folder_dest.name}/{staged.name} is a "
+                        f"different file from the one already in the destination; "
+                        f"both kept, the new one as {target.name}"
+                    )
+                    messages.append(note)
+                    self._write_log(progress_log, f"** {note}")
+            except OSError as exc:
+                unplaced.append(staged)
+                messages.append(f"{staged.name}: {exc}")
+                self._write_log(progress_log, f"!! {staged.name}: {exc}")
+        return placed, skipped, messages, unplaced
+
+    def _download_one_folder(
+        self,
+        model: str,
+        port: str,
+        src_folder: str,
+        destination: Path,
+        timeout_seconds: int,
+        progress_log: TextIO | None = None,
+        expected_total: int | None = None,
+        identity: str | None = None,
+    ) -> tuple[int, int, list[str]]:
+        """Copy one camera folder into the destination without losing a file.
+
+        Files end up in `<destination>/<identity>_<folder tag>/`, never
+        directly in `destination`: `%f` is the bare basename, so a shared
+        destination would make `100NCD80/DSC_0001.NEF` and
+        `101NCD80/DSC_0001.NEF` collide — and, because the folder path is
+        generic across bodies of the same generation, would do the same to
+        two different cameras imported into one destination.
+
+        They get there in three steps, none of which trusts a path:
+
+        1. `--list-files` says what the folder holds and how big each file
+           is. Anything the destination already holds under that name at
+           that size (including as a `-2` alternative from an earlier
+           conflict) is a *candidate* to skip, and is not transferred.
+        2. If the camera's identity is not unique to one body — no serial
+           number — the candidates are not taken on trust: a bounded sample
+           is re-downloaded and compared byte-wise with what is on disk
+           (`_probe_body_identity`). A second body fails that check and its
+           whole folder is fetched.
+        3. Everything fetched lands in a private per-run staging directory
+           and is then moved into place by `_place_staged_files`, which
+           never overwrites and never skips a file it cannot recognise.
+
+        This is what replaced trusting `--skip-existing`: gphoto2 compares
+        *nothing but the target path*, decides inside its own process, and
+        reports a skip that looks exactly like a success, so a second body's
+        `DSC_0001.NEF` used to vanish with no error and a full-looking
+        destination. `--skip-existing` is still passed (it stops gphoto2
+        blocking on an interactive overwrite prompt) but it now only ever
+        sees a directory this run created.
+
+        Costs, honestly: a resume for a body that reports a serial number
+        transfers nothing at all — better than before, where gphoto2 still
+        walked every file. A resume for a body with no serial transfers
+        `PROBE_SAMPLE_SIZE` files per folder. When `--list-files` cannot be
+        parsed, or `src_folder` is "/" (the recursive fallback, where the
+        listing does not describe what the pull will produce), the whole
+        folder is re-fetched into staging every run and placement dedupes it
+        by content — correct, but not cheap; the log says so.
+
+        Args:
+            model: gphoto2 model string.
+            port: gphoto2 port string.
+            src_folder: camera folder to pull.
+            destination: import root; the per-folder subdirectory and the
+                staging area are created underneath it.
+            timeout_seconds: overall budget for this folder, covering the
+                listing, the sample and the transfer.
+            progress_log: open text file handle to receive timestamped
+                "Saving file as ..." lines. None to disable logging.
+            expected_total: if known, formats progress as "(N/total)".
+            identity: camera identity from `_camera_identity`, computed once
+                per camera by the caller so the serial probe is not repeated
+                per folder. None means "derive it from `model` alone", which
+                is the safe fallback for direct callers — never a bare
+                folder tag with no camera in it, and never a claim of
+                uniqueness, so the sample check stays on.
+
+        Returns:
+            Tuple of (files_saved, files_skipped, error_lines). `files_saved`
+            counts files that actually landed in the destination, not lines
+            gphoto2 printed.
+
+        Raises:
+            DarktableMCPError: gphoto2 missing or camera locked by another
+                process (gvfs etc.).
+            subprocess.TimeoutExpired: raised *after* the files that did
+                arrive have been placed, so a re-run resumes from there.
+        """
+        ident = identity if identity is not None else self._model_tag(model)
+        # One source for the directory name: the post-flight check in
+        # `_download_from_camera` resolves it the same way, and a second
+        # spelling here would make it count an empty directory.
+        folder_dest = self._folder_dest(destination, src_folder, ident)
+        folder_dest.mkdir(parents=True, exist_ok=True)
+
+        run_dir = destination / self.STAGING_DIR_NAME / f"{os.getpid()}-{uuid.uuid4().hex[:8]}"
+        stage_folder = run_dir / folder_dest.name
+        stage_folder.mkdir(parents=True, exist_ok=True)
+
+        is_root_pull = self._folder_tag(src_folder) == self.ROOT_FOLDER_TAG
+        pattern = f"{stage_folder}/%F/%f.%C" if is_root_pull else f"{stage_folder}/%f.%C"
+
+        deadline = time.monotonic() + timeout_seconds
+        errors: list[str] = []
+        placed = 0
+        skipped = 0
+        carried = 0
+        timed_out: subprocess.TimeoutExpired | None = None
+
+        try:
+            listing = None if is_root_pull else self._list_files_in_folder(model, port, src_folder)
+            if listing is None:
+                if not is_root_pull:
+                    self._write_log(
+                        progress_log,
+                        f"   (no usable file list for {src_folder}: re-reading the whole "
+                        f"folder this run; files already in the destination are "
+                        f"recognised by content when they are placed)",
+                    )
+                selection: list[str] | None = ["--get-all-files"]
+            else:
+                fetch, skipped, carried, plan_errors = self._plan_folder_fetch(
+                    model,
+                    port,
+                    src_folder,
+                    listing,
+                    folder_dest,
+                    stage_folder,
+                    run_dir / ".probe",
+                    max(1, math.ceil(deadline - time.monotonic())),
+                    ident,
+                    progress_log,
+                )
+                errors.extend(plan_errors)
+                if not fetch:
+                    selection = None
+                elif len(fetch) == len(listing):
+                    selection = ["--get-all-files"]
+                else:
+                    selection = ["--get-file", self._range_expression(fetch)]
+
+            if selection is not None:
+                result = self._run_gphoto2_get(
+                    model,
+                    port,
+                    src_folder,
+                    selection,
+                    pattern,
+                    max(1, math.ceil(deadline - time.monotonic())),
+                    progress_log=progress_log,
+                    expected_total=expected_total,
+                    saved_offset=carried,
+                )
+                errors.extend(result.errors)
+                timed_out = result.timeout
+                if timed_out is not None and result.last_saved:
+                    # The file gphoto2 was writing when the clock ran out is
+                    # truncated. Placing it would put a half photo in the
+                    # destination under the real name, where the next run
+                    # would find it and keep it forever.
+                    partial = Path(result.last_saved)
+                    if partial.is_file() and run_dir in partial.parents:
+                        partial.unlink()
+                        self._write_log(
+                            progress_log,
+                            f"   dropped the partially transferred {partial.name}",
+                        )
+
+            placed, placement_skipped, messages, unplaced = self._place_staged_files(
+                stage_folder, folder_dest, progress_log
+            )
+            skipped += placement_skipped
+            errors.extend(messages)
+
+            if listing is not None:
+                errors.extend(self._report_missing(listing, folder_dest, src_folder, progress_log))
+
+            if unplaced:
+                errors.append(
+                    f"{self.SHORTFALL_PREFIX} {len(unplaced)} file(s) were copied off "
+                    f"the camera but could not be moved into {folder_dest}; they are "
+                    f"still in {stage_folder}"
+                )
+        finally:
+            self._clear_staging(run_dir)
+
+        if timed_out is not None:
+            raise timed_out
+        return placed, skipped, errors
+
+    def _plan_folder_fetch(
+        self,
+        model: str,
+        port: str,
+        src_folder: str,
+        listing: list[_CameraFile],
+        folder_dest: Path,
+        stage_folder: Path,
+        probe_dir: Path,
+        timeout_seconds: int,
+        identity: str,
+        progress_log: TextIO | None = None,
+    ) -> tuple[list[int], int, int, list[str]]:
+        """Decide which of a folder's files actually have to be transferred.
+
+        Returns:
+            (fetch_indices, skipped, carried, errors). `skipped` counts
+            files the destination is trusted to hold already; `carried`
+            counts files the sample check downloaded and left in staging so
+            the main transfer does not pay for them twice.
+        """
+        present = [entry for entry in listing if self._destination_holds(folder_dest, entry)]
+        if not present:
+            return [entry.number for entry in listing], 0, 0, []
+
+        present_numbers = {entry.number for entry in present}
+        if self._identity_is_body_unique(identity):
+            # The serial number makes this directory provably this body's.
+            return (
+                [entry.number for entry in listing if entry.number not in present_numbers],
+                len(present),
+                0,
+                [],
+            )
+
+        verified, fetched, errors = self._probe_body_identity(
+            model,
+            port,
+            src_folder,
+            present,
+            folder_dest,
+            probe_dir,
+            timeout_seconds,
+            progress_log,
+        )
+        if verified:
+            for staged in fetched.values():
+                staged.unlink(missing_ok=True)
+            return (
+                [entry.number for entry in listing if entry.number not in present_numbers],
+                len(present),
+                0,
+                errors,
+            )
+
+        # Another body's photos are in this directory (or the sample could
+        # not be read). Nothing may be skipped on name and size alone; every
+        # file is fetched and `_place_staged_files` decides by content.
+        for name, staged in fetched.items():
+            shutil.move(str(staged), str(stage_folder / name))
+        return (
+            [entry.number for entry in listing if entry.name not in fetched],
+            0,
+            len(fetched),
+            errors,
+        )
+
+    def _report_missing(
+        self,
+        listing: list[_CameraFile],
+        folder_dest: Path,
+        src_folder: str,
+        progress_log: TextIO | None = None,
+    ) -> list[str]:
+        """Name every listed file the destination still does not hold.
+
+        The whole point of the module is that a photo is never lost without
+        the user hearing about it. Everything else here is best effort; this
+        is the check that turns "best effort" into a statement, because it
+        compares what the card said it had against what is on disk after the
+        transfer, per file and by name.
+        """
+        missing = [
+            entry.name for entry in listing if not self._destination_holds(folder_dest, entry)
+        ]
+        if not missing:
+            return []
+        shown = ", ".join(missing[:5])
+        if len(missing) > 5:
+            shown += f", ... ({len(missing) - 5} more)"
+        message = (
+            f"{self.SHORTFALL_PREFIX} {len(missing)} file(s) listed in {src_folder} "
+            f"are still not in {folder_dest.name}/: {shown}"
+        )
+        self._write_log(progress_log, f"!! {message}")
+        return [message]
+
+    def _clear_staging(self, run_dir: Path) -> None:
+        """Remove this run's staging directory, keeping anything unplaced.
+
+        `rmtree` only when the tree holds no files: a file still sitting in
+        staging is a photo that came off the camera and could not be put
+        anywhere, and deleting it is exactly the data loss this module
+        exists to prevent. The caller has already reported where it is.
+        """
+        try:
+            if not run_dir.exists():
+                return
+            if any(p.is_file() for p in run_dir.rglob("*")):
+                return
+            shutil.rmtree(run_dir, ignore_errors=True)
+            parent = run_dir.parent
+            if parent.name == self.STAGING_DIR_NAME and not any(parent.iterdir()):
+                parent.rmdir()
+        except OSError:  # pragma: no cover - cleanup is best-effort
+            pass
 
     def _count_files_on_disk(self, destination: Path) -> int:
         """Count files under the destination, recursively, ignoring the log.
@@ -572,13 +1302,19 @@ class CameraTools:
         Recursive because every source folder now gets its own
         subdirectory — a flat `iterdir()` would count zero and make the
         post-flight shortfall check fire on a perfectly good import.
+
+        The staging area is excluded: files in it have not been placed yet,
+        and counting them would let a half-finished transfer paper over a
+        shortfall.
         """
         if not destination.exists():
             return 0
         return sum(
             1
             for entry in destination.rglob("*")
-            if entry.is_file() and entry.name != self.PROGRESS_LOG_NAME
+            if entry.is_file()
+            and entry.name != self.PROGRESS_LOG_NAME
+            and self.STAGING_DIR_NAME not in entry.parts
         )
 
     # ---- USB Mass Storage handling -----------------------------------------
@@ -744,17 +1480,20 @@ class CameraTools:
             return f"{name}-{index}"
         return f"{stem}-{index}{dot}{ext}"
 
-    def _msc_target_path(self, src: Path, sub_dest: Path) -> Path | None:
-        """Decide where one card file may be written, or that it is present.
+    def _never_overwrite_target(self, src: Path, sub_dest: Path) -> Path | None:
+        """Decide where one incoming file may be written, or that it is present.
 
-        The one rule: never overwrite, and never skip, a file that is not
+        Shared by both import paths — the MSC walker copies into it, the PTP
+        path moves staged downloads through it — because both need the same
+        one rule: never overwrite, and never skip, a file that is not
         provably the file we already have. `shutil.copy2` onto an occupied
         path destroys a photo that was already safely on disk — the exact
         failure this whole module is written to prevent — and skipping on a
         bare size match destroys it just as effectively by never copying it.
 
         Args:
-            src: file on the card.
+            src: incoming file — on the card, or already downloaded into the
+                per-run staging directory.
             sub_dest: destination subdirectory for its source folder.
 
         Returns:
@@ -800,7 +1539,7 @@ class CameraTools:
         but a card label is not a device identity — two cards formatted in
         the same body are both `EOS_DIGITAL`, and a single-slot reader
         mounts them at the same path — so the directory is never trusted on
-        its own. Every write goes through `_msc_target_path`, which:
+        its own. Every write goes through `_never_overwrite_target`, which:
 
         - copies when nothing is in the way;
         - skips, counting a skip, when the destination file still looks like
@@ -878,7 +1617,7 @@ class CameraTools:
                     break
                 try:
                     sub_dest.mkdir(parents=True, exist_ok=True)
-                    dst = self._msc_target_path(src, sub_dest)
+                    dst = self._never_overwrite_target(src, sub_dest)
                     if dst is None:
                         skipped += 1
                         continue
@@ -925,6 +1664,9 @@ class CameraTools:
           `<dest>/<camera identity>_<folder tag>/` subdirectory, so
           same-named files from different folders, different cards or
           different bodies cannot overwrite or "skip-existing" each other.
+          Two bodies that share an identity share the subdirectory, and
+          `_download_one_folder` keeps both sets of photos there by
+          comparing bytes rather than paths.
         - During transfer: stream per-file progress to <dest>/.import.log
           so the user can `tail -f` it.
         - `timeout_seconds` is an overall budget for this camera, not a
@@ -938,9 +1680,10 @@ class CameraTools:
           shortfall warning so silent under-copies are visible. It counts
           the identity-prefixed directories this camera actually wrote to,
           so it stays honest when another body imported into the same
-          destination. It cannot see a `--skip-existing` drop between two
-          same-model bodies with no serial number, because such a drop
-          leaves a full destination — see `_download_one_folder`.
+          destination. `_download_one_folder` adds a sharper, per-file
+          version of the same check whenever it could read a file list:
+          every listed name that is still not in the destination is
+          reported by name.
 
         Args:
             model: gphoto2 model string (e.g. "Nikon DSC D800E").
@@ -1107,11 +1850,9 @@ class CameraTools:
         flattening them silently dropped duplicates. The identity is the
         camera model plus its serial number when it reports one; two bodies
         of the same model that report no serial share a subdirectory, and
-        on the PTP path that is the one case where a same-named photo can
-        still be dropped without an error — import such bodies into separate
-        destinations. The USB-Mass-Storage path keeps both regardless: it
-        never overwrites and never skips a file it cannot recognise, writing
-        the newcomer as `IMG_0001-2.CR3` and saying so. Per-file progress is
+        both paths keep both sets of photos in it — neither ever overwrites
+        or skips a file it cannot recognise by content, writing the newcomer
+        as `IMG_0001-2.CR3` and saying so. Per-file progress is
         streamed to a log file inside the destination so long imports can
         be monitored with `tail -f`. Registering the directory with
         darktable's library is left to the user (open darktable, click
@@ -1198,9 +1939,10 @@ class CameraTools:
                 if total_count == 0 and not all_errors:
                     raise DarktableMCPError(
                         f"Camera transfer timed out after {timeout_seconds} s. "
-                        f"Destination {destination} may contain partial files. "
-                        "Re-run the tool to resume — `--skip-existing` is on, "
-                        "so already-copied files are not re-downloaded."
+                        f"Destination {destination} holds everything that was "
+                        "copied before the clock ran out. Re-run the tool to "
+                        "resume — files already in the destination are "
+                        "recognised and not fetched again."
                     ) from exc
                 all_errors.append(f"{entry['model']} ({entry['port']}) timed out")
                 continue

--- a/darktable_mcp/tools/camera_tools.py
+++ b/darktable_mcp/tools/camera_tools.py
@@ -10,10 +10,9 @@ import threading
 import time
 from datetime import date, datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional, TextIO, Tuple
+from typing import Any, TextIO
 
 from ..utils.errors import DarktableMCPError
-
 
 logger = logging.getLogger(__name__)
 
@@ -87,9 +86,9 @@ class CameraTools:
     #: stderr of the last `--auto-detect` that exited non-zero yet still
     #: parsed cameras. Surfaced in the import summary so a partially failed
     #: detect is distinguishable from a clean one.
-    last_detect_warning: Optional[str] = None
+    last_detect_warning: str | None = None
 
-    def _detect_cameras(self) -> List[Dict[str, str]]:
+    def _detect_cameras(self) -> list[dict[str, str]]:
         """Run `gphoto2 --auto-detect` and return parsed list of cameras.
 
         A non-zero exit code with cameras still parsed means the detect
@@ -125,7 +124,7 @@ class CameraTools:
                 "Is the camera busy or the USB connection unstable?"
             ) from exc
 
-        cameras: List[Dict[str, str]] = []
+        cameras: list[dict[str, str]] = []
         for line in result.stdout.splitlines():
             stripped = line.strip()
             # Skip header ("Model ... Port") and separator ("----...")
@@ -150,7 +149,7 @@ class CameraTools:
             logger.warning("%s", self.last_detect_warning)
         return cameras
 
-    def _list_image_folders(self, model: str, port: str) -> List[str]:
+    def _list_image_folders(self, model: str, port: str) -> list[str]:
         """Enumerate leaf folders (no subfolders) on the camera.
 
         Multi-storage cameras (dual CF/SD bodies, etc.) expose each card as
@@ -188,7 +187,7 @@ class CameraTools:
         if result.returncode != 0:
             return ["/"]
 
-        leaves: List[str] = []
+        leaves: list[str] = []
         for line in result.stdout.splitlines():
             match = self._FOLDER_LINE_RE.search(line)
             if not match:
@@ -202,9 +201,7 @@ class CameraTools:
             return ["/"]
         return sorted(leaves)
 
-    def _count_files_in_folder(
-        self, model: str, port: str, src_folder: str
-    ) -> Optional[int]:
+    def _count_files_in_folder(self, model: str, port: str, src_folder: str) -> int | None:
         """Count files in a single camera folder via `--num-files`.
 
         Returns None on any failure (gphoto2 missing, timeout, parse error).
@@ -261,7 +258,7 @@ class CameraTools:
         kept = [w for w in words if w.upper() not in _GENERIC_MODEL_WORDS]
         return "_".join(kept)
 
-    def _probe_serial(self, model: str, port: str) -> Optional[str]:
+    def _probe_serial(self, model: str, port: str) -> str | None:
         """Ask the camera for its serial number. None whenever that fails.
 
         Deliberately total: most compacts, many DSLRs and every MSC mount
@@ -394,10 +391,10 @@ class CameraTools:
         src_folder: str,
         destination: Path,
         timeout_seconds: int,
-        progress_log: Optional[TextIO] = None,
-        expected_total: Optional[int] = None,
-        identity: Optional[str] = None,
-    ) -> Tuple[int, int, List[str]]:
+        progress_log: TextIO | None = None,
+        expected_total: int | None = None,
+        identity: str | None = None,
+    ) -> tuple[int, int, list[str]]:
         """Run gphoto2 to copy all files in a single camera folder.
 
         Files land in `<destination>/<identity>_<folder tag>/`, never
@@ -493,7 +490,7 @@ class CameraTools:
             ) from exc
 
         counters = {"saved": 0, "skipped": 0}
-        stderr_buf: List[str] = []
+        stderr_buf: list[str] = []
 
         def _consume_stdout() -> None:
             stream = proc.stdout
@@ -549,7 +546,7 @@ class CameraTools:
         skipped = counters["skipped"]
         returncode = proc.returncode if proc.returncode is not None else 0
 
-        errors: List[str] = []
+        errors: list[str] = []
         if returncode != 0:
             errors.extend(line.rstrip() for line in stderr_buf if line.strip())
 
@@ -601,7 +598,7 @@ class CameraTools:
     @staticmethod
     def _msc_mount(port: str) -> Path:
         """Strip the `disk:` prefix and return the mount point as a Path."""
-        return Path(port[len(_MSC_PORT_PREFIX):])
+        return Path(port[len(_MSC_PORT_PREFIX) :])
 
     @staticmethod
     def _msc_matches_ptp(msc_port: str, ptp_model: str) -> bool:
@@ -615,14 +612,12 @@ class CameraTools:
         """
         if not msc_port.startswith(_MSC_PORT_PREFIX):
             return False
-        basename = Path(msc_port[len(_MSC_PORT_PREFIX):]).name
+        basename = Path(msc_port[len(_MSC_PORT_PREFIX) :]).name
         model_words = {w.upper() for w in _MODEL_WORD_RE.findall(ptp_model)}
         mount_words = {w.upper() for w in _MODEL_WORD_RE.findall(basename)}
         return bool(model_words & mount_words)
 
-    def _group_cameras(
-        self, cameras: List[Dict[str, str]]
-    ) -> List[List[Dict[str, str]]]:
+    def _group_cameras(self, cameras: list[dict[str, str]]) -> list[list[dict[str, str]]]:
         """Group MSC mounts with the PTP camera they likely belong to.
 
         Returns a list of groups; each group is a non-empty list of camera
@@ -636,7 +631,7 @@ class CameraTools:
         ptp = [c for c in cameras if not self._is_msc_port(c["port"])]
 
         used: set = set()
-        groups: List[List[Dict[str, str]]] = []
+        groups: list[list[dict[str, str]]] = []
         for ptp_cam in ptp:
             group = [ptp_cam]
             for i, msc_cam in enumerate(msc):
@@ -749,7 +744,7 @@ class CameraTools:
             return f"{name}-{index}"
         return f"{stem}-{index}{dot}{ext}"
 
-    def _msc_target_path(self, src: Path, sub_dest: Path) -> Optional[Path]:
+    def _msc_target_path(self, src: Path, sub_dest: Path) -> Path | None:
         """Decide where one card file may be written, or that it is present.
 
         The one rule: never overwrite, and never skip, a file that is not
@@ -796,7 +791,7 @@ class CameraTools:
         destination: Path,
         timeout_seconds: int = DOWNLOAD_TIMEOUT_DEFAULT,
         model: str = "",
-    ) -> Tuple[int, int, List[str]]:
+    ) -> tuple[int, int, list[str]]:
         """Copy DCIM-shaped files from a USB Mass-Storage card mount.
 
         Walks `<mount>/DCIM/<subdir>/` for image and video files and copies
@@ -845,7 +840,7 @@ class CameraTools:
             return 0, 0, [f"no DCIM/ folder under {mount}"]
 
         # (source file, destination subdirectory) pairs, folder by folder.
-        images: List[Tuple[Path, Path]] = []
+        images: list[tuple[Path, Path]] = []
         for sub in sorted(dcim.iterdir()):
             if sub.is_dir():
                 sub_dest = destination / self._msc_folder_tag(mount, sub, model)
@@ -857,7 +852,7 @@ class CameraTools:
         log_path = destination / self.PROGRESS_LOG_NAME
         saved = 0
         skipped = 0
-        errors: List[str] = []
+        errors: list[str] = []
 
         with open(log_path, "a", encoding="utf-8") as log:
             log.write(
@@ -920,7 +915,7 @@ class CameraTools:
         port: str,
         destination: Path,
         timeout_seconds: int = DOWNLOAD_TIMEOUT_DEFAULT,
-    ) -> Tuple[int, int, List[str]]:
+    ) -> tuple[int, int, list[str]]:
         """Copy all files from a camera, walking each storage folder.
 
         - Pre-flight: resolve this camera's identity once (one gphoto2 call
@@ -987,7 +982,7 @@ class CameraTools:
         folders = self._list_image_folders(model, port)
 
         # Pre-flight expected counts (best-effort; skips if --num-files fails).
-        expected_per_folder: List[Optional[int]] = []
+        expected_per_folder: list[int | None] = []
         expected_total = 0
         for folder in folders:
             try:
@@ -1001,13 +996,12 @@ class CameraTools:
         log_path = destination / self.PROGRESS_LOG_NAME
         total_count = 0
         total_skipped = 0
-        all_errors: List[str] = []
+        all_errors: list[str] = []
 
         log = open(log_path, "a", encoding="utf-8")
         try:
             log.write(
-                f"\n=== Import started "
-                f"{datetime.now().isoformat(timespec='seconds')} ===\n"
+                f"\n=== Import started " f"{datetime.now().isoformat(timespec='seconds')} ===\n"
             )
             log.write(f"Camera: {model} ({port})\n")
             log.write(f"Camera identity tag: {identity or '(none available)'}\n")
@@ -1018,9 +1012,7 @@ class CameraTools:
             )
             log.flush()
 
-            for position, (folder, expected) in enumerate(
-                zip(folders, expected_per_folder)
-            ):
+            for position, (folder, expected) in enumerate(zip(folders, expected_per_folder)):
                 # Overall budget: each folder only gets what is left of it.
                 remaining = math.ceil(deadline - time.monotonic())
                 if remaining <= 0:
@@ -1072,17 +1064,14 @@ class CameraTools:
                 total_skipped += skipped
                 all_errors.extend(errors)
                 log.write(
-                    f"-- Folder {folder} done: {saved} new file(s), "
-                    f"{skipped} skipped --\n"
+                    f"-- Folder {folder} done: {saved} new file(s), " f"{skipped} skipped --\n"
                 )
                 log.flush()
 
             # Count only the folders belonging to this camera, so files put
             # here by another card in the same import don't mask a shortfall.
             disk_count = sum(
-                self._count_files_on_disk(
-                    self._folder_dest(destination, folder, identity)
-                )
+                self._count_files_on_disk(self._folder_dest(destination, folder, identity))
                 for folder in folders
             )
             if expected_total and disk_count < expected_total:
@@ -1106,7 +1095,7 @@ class CameraTools:
 
         return total_count, total_skipped, all_errors
 
-    def import_from_camera(self, arguments: Dict[str, Any]) -> str:
+    def import_from_camera(self, arguments: dict[str, Any]) -> str:
         """Copy all photos from a connected camera to a local directory.
 
         Detects connected cameras via gphoto2 (libgphoto2 — same library
@@ -1172,8 +1161,7 @@ class CameraTools:
             if target_group is None:
                 ports = ", ".join(c["port"] for c in cameras)
                 raise DarktableMCPError(
-                    f"camera_port '{camera_port}' not found. "
-                    f"Detected ports: {ports}"
+                    f"camera_port '{camera_port}' not found. " f"Detected ports: {ports}"
                 )
         elif len(groups) > 1:
             listing = "; ".join(
@@ -1200,7 +1188,7 @@ class CameraTools:
         # successful import beats no import at all.
         total_count = 0
         total_skipped = 0
-        all_errors: List[str] = []
+        all_errors: list[str] = []
         for entry in target_group:
             try:
                 count, skipped, errors = self._download_from_camera(
@@ -1214,9 +1202,7 @@ class CameraTools:
                         "Re-run the tool to resume — `--skip-existing` is on, "
                         "so already-copied files are not re-downloaded."
                     ) from exc
-                all_errors.append(
-                    f"{entry['model']} ({entry['port']}) timed out"
-                )
+                all_errors.append(f"{entry['model']} ({entry['port']}) timed out")
                 continue
             except DarktableMCPError as exc:
                 if total_count == 0 and not all_errors:
@@ -1241,9 +1227,7 @@ class CameraTools:
         shortfalls = [e for e in all_errors if e.startswith(self.SHORTFALL_PREFIX)]
         renames = [e for e in all_errors if e.startswith(self.RENAMED_PREFIX)]
         other_errors = [
-            e
-            for e in all_errors
-            if not e.startswith((self.SHORTFALL_PREFIX, self.RENAMED_PREFIX))
+            e for e in all_errors if not e.startswith((self.SHORTFALL_PREFIX, self.RENAMED_PREFIX))
         ]
 
         summary_parts = [
@@ -1252,15 +1236,18 @@ class CameraTools:
             f"Destination: {destination} ({disk_count} files on disk, "
             "one subdirectory per camera folder)",
             f"Progress log: {log_path}",
-            f"  Tail in another terminal during long imports: tail -f \"{log_path}\"",
-            "Open darktable and choose 'import folder' on this directory to add them to your library.",
+            f'  Tail in another terminal during long imports: tail -f "{log_path}"',
+            # Copying is not importing. Point at the tool that finishes the
+            # job rather than at manual GUI steps: import_batch registers the
+            # destination as a film roll over the Lua bridge.
+            f"Next: call import_batch on {destination} to register these "
+            "photos in the darktable library (it recurses into the "
+            "per-camera subdirectories).",
         ]
         if shortfalls:
             # Loud on purpose: the user is about to format the card.
             summary_parts.append("")
-            summary_parts.append(
-                "!! INCOMPLETE IMPORT — some photos did not make it off the card:"
-            )
+            summary_parts.append("!! INCOMPLETE IMPORT — some photos did not make it off the card:")
             summary_parts.extend(f"     {msg}" for msg in shortfalls)
             summary_parts.append(
                 "   Do NOT format the card. Re-run this tool to fetch the "
@@ -1280,9 +1267,7 @@ class CameraTools:
             if len(renames) > 5:
                 summary_parts.append(f"     ... and {len(renames) - 5} more (see the log)")
         if other_errors:
-            summary_parts.append(
-                f"Warning: {len(other_errors)} issue(s). First: {other_errors[0]}"
-            )
+            summary_parts.append(f"Warning: {len(other_errors)} issue(s). First: {other_errors[0]}")
         if self.last_detect_warning:
             summary_parts.append(f"Note: {self.last_detect_warning}")
         return "\n".join(summary_parts)

--- a/darktable_mcp/tools/preview_tools.py
+++ b/darktable_mcp/tools/preview_tools.py
@@ -18,9 +18,10 @@ import subprocess
 import tempfile
 import threading
 import time
+from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from typing import Any, Dict, List, Mapping, Optional, Tuple
+from typing import Any
 
 from ..utils.errors import DarktableMCPError
 
@@ -30,30 +31,45 @@ logger = logging.getLogger(__name__)
 # against this set, never `p.suffix`. A `.Nef` is a NEF.
 RAW_EXTENSIONS = frozenset(
     {
-        ".nef", ".nrw",           # Nikon
-        ".cr2", ".cr3", ".crw",   # Canon
-        ".arw", ".srf", ".sr2",   # Sony
-        ".raf",                   # Fujifilm
-        ".rw2",                   # Panasonic
-        ".dng",                   # Adobe / generic
-        ".orf",                   # Olympus
-        ".pef",                   # Pentax
-        ".srw",                   # Samsung
-        ".rwl",                   # Leica
-        ".erf",                   # Epson
-        ".mrw",                   # Minolta
-        ".x3f",                   # Sigma
-        ".iiq",                   # Phase One
-        ".3fr", ".fff",           # Hasselblad
-        ".kdc", ".dcr",           # Kodak
-        ".mos",                   # Leaf
+        ".nef",
+        ".nrw",  # Nikon
+        ".cr2",
+        ".cr3",
+        ".crw",  # Canon
+        ".arw",
+        ".srf",
+        ".sr2",  # Sony
+        ".raf",  # Fujifilm
+        ".rw2",  # Panasonic
+        ".dng",  # Adobe / generic
+        ".orf",  # Olympus
+        ".pef",  # Pentax
+        ".srw",  # Samsung
+        ".rwl",  # Leica
+        ".erf",  # Epson
+        ".mrw",  # Minolta
+        ".x3f",  # Sigma
+        ".iiq",  # Phase One
+        ".3fr",
+        ".fff",  # Hasselblad
+        ".kdc",
+        ".dcr",  # Kodak
+        ".mos",  # Leaf
     }
 )
 
 # Preference order when several raws share one stem (e.g. an in-camera DNG
 # next to the native NEF). Anything not listed sorts after these, by name.
 RAW_EXTENSION_PREFERENCE = (
-    ".nef", ".cr3", ".cr2", ".arw", ".raf", ".rw2", ".orf", ".pef", ".dng",
+    ".nef",
+    ".cr3",
+    ".cr2",
+    ".arw",
+    ".raf",
+    ".rw2",
+    ".orf",
+    ".pef",
+    ".dng",
 )
 
 ISO_KEYS = (
@@ -101,9 +117,9 @@ _UNRECOGNISED_SIDECAR = (
 def _import_vision_libs():
     """Lazy-import the optional [vision] deps with a helpful error."""
     try:
+        import pyexiv2  # type: ignore[import-untyped]
         import rawpy  # type: ignore[import-untyped]
         from PIL import Image, ImageOps  # type: ignore[import-untyped]
-        import pyexiv2  # type: ignore[import-untyped]
     except ImportError as exc:
         raise DarktableMCPError(
             "Vision-rating tools require optional deps. Install with: "
@@ -113,7 +129,7 @@ def _import_vision_libs():
     return rawpy, Image, ImageOps, pyexiv2
 
 
-def _coerce_iso(value: Any) -> Optional[int]:
+def _coerce_iso(value: Any) -> int | None:
     """Coerce a raw EXIF ISO value into a sensible int; return None if unusable."""
     if value is None:
         return None
@@ -122,7 +138,7 @@ def _coerce_iso(value: Any) -> Optional[int]:
             return None
         value = value[0]
     if isinstance(value, str):
-        nums: List[int] = []
+        nums: list[int] = []
         for part in value.replace("/", " ").split():
             try:
                 nums.append(int(part))
@@ -137,7 +153,7 @@ def _coerce_iso(value: Any) -> Optional[int]:
     return n if 50 <= n <= 102400 else None
 
 
-def _parse_rational(value: Any) -> Optional[float]:
+def _parse_rational(value: Any) -> float | None:
     """Parse pyexiv2 'a/b' rational-string into float."""
     if value is None:
         return None
@@ -156,9 +172,9 @@ def _parse_rational(value: Any) -> Optional[float]:
         return None
 
 
-def _read_exif_summary(pyexiv2_mod: Any, raw_path: Path) -> Dict[str, Any]:
+def _read_exif_summary(pyexiv2_mod: Any, raw_path: Path) -> dict[str, Any]:
     """Read a small, useful EXIF summary from a raw file."""
-    summary: Dict[str, Any] = {
+    summary: dict[str, Any] = {
         "iso": None,
         "shutter": None,
         "focal_mm": None,
@@ -186,18 +202,14 @@ def _read_exif_summary(pyexiv2_mod: Any, raw_path: Path) -> Dict[str, Any]:
                 summary["iso"] = iso
                 break
 
-    summary["shutter"] = exif.get("Exif.Photo.ExposureTime") or exif.get(
-        "Exif.Image.ExposureTime"
-    )
+    summary["shutter"] = exif.get("Exif.Photo.ExposureTime") or exif.get("Exif.Image.ExposureTime")
     summary["focal_mm"] = _parse_rational(exif.get("Exif.Photo.FocalLength"))
     summary["aperture"] = _parse_rational(exif.get("Exif.Photo.FNumber"))
-    summary["datetime"] = exif.get("Exif.Photo.DateTimeOriginal") or exif.get(
-        "Exif.Image.DateTime"
-    )
+    summary["datetime"] = exif.get("Exif.Photo.DateTimeOriginal") or exif.get("Exif.Image.DateTime")
     return summary
 
 
-def _raw_sort_key(path: Path) -> Tuple[int, str]:
+def _raw_sort_key(path: Path) -> tuple[int, str]:
     """Sort key ranking raws by format preference, then by filename."""
     ext = path.suffix.lower()
     try:
@@ -215,7 +227,7 @@ def _is_within(path: Path, base: Path) -> bool:
         return False
 
 
-def _iter_raw_files(source_dir: Path, exclude: Optional[Path] = None) -> List[Path]:
+def _iter_raw_files(source_dir: Path, exclude: Path | None = None) -> list[Path]:
     """Recursively list the raw files under ``source_dir``, in sorted path order.
 
     ``import_from_camera`` writes one subdirectory per camera folder / card
@@ -231,7 +243,7 @@ def _iter_raw_files(source_dir: Path, exclude: Optional[Path] = None) -> List[Pa
     except OSError as exc:
         raise DarktableMCPError(f"cannot scan source_dir {source_dir}: {exc}") from exc
 
-    matches: List[Path] = []
+    matches: list[Path] = []
     for path in entries:
         if path.suffix.lower() not in RAW_EXTENSIONS:
             continue
@@ -249,26 +261,26 @@ def _iter_raw_files(source_dir: Path, exclude: Optional[Path] = None) -> List[Pa
     return sorted(matches, key=lambda p: p.parts)
 
 
-def _raw_lookup_keys(source_dir: Path, path: Path) -> List[str]:
+def _raw_lookup_keys(source_dir: Path, path: Path) -> list[str]:
     """Keys a caller may use for ``path``: the bare stem and the relative path."""
     rel_key = path.relative_to(source_dir).with_suffix("").as_posix()
     return [path.stem] if rel_key == path.stem else [path.stem, rel_key]
 
 
-def _index_raws(source_dir: Path, exclude: Optional[Path] = None) -> Dict[str, List[Path]]:
+def _index_raws(source_dir: Path, exclude: Path | None = None) -> dict[str, list[Path]]:
     """Index the raws under ``source_dir`` by bare stem AND by relative path.
 
     Built once per batch: a per-stem ``rglob`` would rescan the whole tree for
     every one of several hundred ratings.
     """
-    index: Dict[str, List[Path]] = {}
+    index: dict[str, list[Path]] = {}
     for path in _iter_raw_files(source_dir, exclude=exclude):
         for key in _raw_lookup_keys(source_dir, path):
             index.setdefault(key, []).append(path)
     return index
 
 
-def _lookup_raws(index: Mapping[str, List[Path]], key: str) -> List[Path]:
+def _lookup_raws(index: Mapping[str, list[Path]], key: str) -> list[Path]:
     """Resolve a ratings key (bare stem or source-relative path) to raw paths."""
     normalized = Path(key).as_posix().lstrip("/")
     if normalized.startswith("./"):
@@ -280,7 +292,7 @@ def _lookup_raws(index: Mapping[str, List[Path]], key: str) -> List[Path]:
     return sorted(matches, key=_raw_sort_key) if matches else []
 
 
-def _find_raws_for_stem(source_dir: Path, stem: str) -> List[Path]:
+def _find_raws_for_stem(source_dir: Path, stem: str) -> list[Path]:
     """List every raw under ``source_dir`` matching ``stem``, best candidate first.
 
     ``stem`` is either a bare stem (``DSC_1234``) or a path relative to
@@ -294,7 +306,7 @@ def _find_raws_for_stem(source_dir: Path, stem: str) -> List[Path]:
     return _lookup_raws(_index_raws(source_dir), stem)
 
 
-def _resolve_raw_for_stem(source_dir: Path, stem: str) -> Optional[Path]:
+def _resolve_raw_for_stem(source_dir: Path, stem: str) -> Path | None:
     """Find the best raw for ``stem`` under ``source_dir`` (recursive, case-insensitive)."""
     matches = _find_raws_for_stem(source_dir, stem)
     return matches[0] if matches else None
@@ -339,7 +351,7 @@ def _atomic_write_bytes(path: Path, data: bytes) -> None:
     gets ``_NEW_FILE_MODE``. Never touches the process umask.
     """
     try:
-        mode: Optional[int] = path.stat().st_mode & 0o777
+        mode: int | None = path.stat().st_mode & 0o777
     except OSError:
         mode = None
 
@@ -359,7 +371,7 @@ def _atomic_write_bytes(path: Path, data: bytes) -> None:
         raise
 
 
-def _patch_rating(existing: bytes, rating: int) -> Optional[bytes]:
+def _patch_rating(existing: bytes, rating: int) -> bytes | None:
     """Rewrite only the rating value inside an existing sidecar.
 
     Returns the patched bytes (everything else byte-identical), or None when no
@@ -368,9 +380,7 @@ def _patch_rating(existing: bytes, rating: int) -> Optional[bytes]:
     """
     value = str(rating).encode("ascii")
     for pattern in (_RATING_ELEMENT_RE, _RATING_ATTR_RE):
-        patched, count = pattern.subn(
-            lambda m: m.group(1) + value + m.group(3), existing, count=1
-        )
+        patched, count = pattern.subn(lambda m: m.group(1) + value + m.group(3), existing, count=1)
         if count:
             return patched
     return None
@@ -410,12 +420,12 @@ def _default_workers() -> int:
 
 def extract_previews(
     source_dir: str | Path,
-    output_dir: Optional[str | Path] = None,
+    output_dir: str | Path | None = None,
     max_dim: int = 1024,
     thumb_dim: int = 384,
     overwrite: bool = False,
-    max_workers: Optional[int] = None,
-) -> Dict[str, Any]:
+    max_workers: int | None = None,
+) -> dict[str, Any]:
     """Extract auto-rotated JPEG previews from raw files for vision rating.
 
     For each raw file in ``source_dir``:
@@ -453,7 +463,8 @@ def extract_previews(
     disambiguate. Per-file errors are reported per-item, never raised — one
     bad raw can't sink the batch.
     """
-    rawpy, Image, ImageOps, pyexiv2 = _import_vision_libs()
+    # N806: Image/ImageOps are PIL classes, so CapWords is their real name.
+    rawpy, Image, ImageOps, pyexiv2 = _import_vision_libs()  # noqa: N806
 
     src = Path(source_dir).expanduser().resolve()
     if not src.is_dir():
@@ -473,18 +484,16 @@ def extract_previews(
 
     raws = _iter_raw_files(src, exclude=out_dir)
 
-    def _extract_one(raw: Path) -> Tuple[Dict[str, Any], str]:
+    def _extract_one(raw: Path) -> tuple[dict[str, Any], str]:
         """Extract one raw. Returns (item, status) with status in extracted/skipped/error."""
         # Mirror the source tree under the output dir. Camera filenames repeat
         # across folders and cards, so a flat `<out_dir>/<stem>.jpg` would let
         # `a/DSC_0001.NEF` and `b/DSC_0001.NEF` silently overwrite each other.
         rel_parent = raw.parent.relative_to(src)
         out_path = out_dir / rel_parent / f"{raw.stem}.jpg"
-        thumb_path = (
-            thumb_dir / rel_parent / f"{raw.stem}.jpg" if thumb_dir is not None else None
-        )
+        thumb_path = thumb_dir / rel_parent / f"{raw.stem}.jpg" if thumb_dir is not None else None
 
-        item: Dict[str, Any] = {
+        item: dict[str, Any] = {
             "stem": raw.stem,
             "rel_path": raw.relative_to(src).as_posix(),
             "source": str(raw),
@@ -555,8 +564,7 @@ def extract_previews(
                 fh.write(json.dumps(it) + "\n")
     except OSError as exc:
         raise DarktableMCPError(
-            f"cannot write details file {side_file}: {exc}. "
-            "Is the output directory read-only?"
+            f"cannot write details file {side_file}: {exc}. " "Is the output directory read-only?"
         ) from exc
 
     return {
@@ -575,7 +583,7 @@ def apply_ratings_batch(
     ratings: Mapping[str, int],
     log: bool = True,
     force: bool = False,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Write XMP sidecars for a batch of ``{key: rating}`` pairs.
 
     The sidecar sits next to its raw, at ``<raw path>.xmp``. Rating range is
@@ -616,15 +624,15 @@ def apply_ratings_batch(
         raise DarktableMCPError(f"source_dir is not a directory: {src}")
 
     log_path = src / "ratings.jsonl" if log else None
-    items: List[Dict[str, Any]] = []
+    items: list[dict[str, Any]] = []
     applied = errors = 0
-    log_entries: List[str] = []
+    log_entries: list[str] = []
     now = time.time()
     # One recursive scan for the whole batch, not one per rating.
     index = _index_raws(src)
 
     for stem, rating in ratings.items():
-        result: Dict[str, Any] = {
+        result: dict[str, Any] = {
             "stem": stem,
             "rating": rating,
             "sidecar": None,
@@ -686,7 +694,7 @@ def apply_ratings_batch(
             continue
 
         if existing is None:
-            payload: Optional[bytes] = XMP_TEMPLATE.format(rating=r).encode("utf-8")
+            payload: bytes | None = XMP_TEMPLATE.format(rating=r).encode("utf-8")
             action = "created"
         elif force:
             payload = XMP_TEMPLATE.format(rating=r).encode("utf-8")
@@ -793,9 +801,7 @@ def format_ratings_summary(result: Mapping[str, Any]) -> str:
 
     if result["errors"]:
         bad = [it for it in result["items"] if it.get("error")]
-        line += "\nfailures:\n" + "\n".join(
-            f"  {it['stem']}: {it['error']}" for it in bad[:10]
-        )
+        line += "\nfailures:\n" + "\n".join(f"  {it['stem']}: {it['error']}" for it in bad[:10])
         if len(bad) > 10:
             line += f"\n  ... and {len(bad) - 10} more"
     return line
@@ -808,10 +814,10 @@ _DT_PROP_FILMROLL = 0
 
 
 def _normalize_rating_range(
-    rating: Optional[int],
-    rating_min: Optional[int],
-    rating_max: Optional[int],
-) -> Optional[Tuple[int, int]]:
+    rating: int | None,
+    rating_min: int | None,
+    rating_max: int | None,
+) -> tuple[int, int] | None:
     """Return (lo, hi) for the rating filter, or None when no filter is requested.
 
     Accepts either a single ``rating`` (exact match) or a ``rating_min`` /
@@ -819,9 +825,7 @@ def _normalize_rating_range(
     in the darktable-supported range ``[-1, 5]`` (-1 = reject).
     """
     if rating is not None and (rating_min is not None or rating_max is not None):
-        raise DarktableMCPError(
-            "Pass either `rating` or `rating_min`/`rating_max`, not both."
-        )
+        raise DarktableMCPError("Pass either `rating` or `rating_min`/`rating_max`, not both.")
 
     if rating is not None:
         lo = hi = int(rating)
@@ -832,20 +836,20 @@ def _normalize_rating_range(
         hi = int(rating_max) if rating_max is not None else 5
 
     if lo < -1 or hi > 5 or lo > hi:
-        raise DarktableMCPError(
-            f"rating range out of bounds [-1, 5]: lo={lo}, hi={hi}"
-        )
+        raise DarktableMCPError(f"rating range out of bounds [-1, 5]: lo={lo}, hi={hi}")
     return lo, hi
 
 
 def _format_rating_label(lo: int, hi: int) -> str:
     """Format a rating range as a human-readable hint (e.g. '★★★★★', 'rejected', '★★ to ★★★★')."""
+
     def stars(n: int) -> str:
         if n == -1:
             return "rejected"
         if n == 0:
             return "unstarred"
         return "★" * n
+
     if lo == hi:
         return stars(lo)
     return f"{stars(lo)} to {stars(hi)}"
@@ -855,6 +859,7 @@ def _format_rating_label(lo: int, hi: int) -> str:
 # API 9.6.0 that can drive the rating filter externally. The new
 # filtering panel doesn't expose Lua bindings; the simple-mode filter
 # library doesn't have a `rating` field.
+
 
 def _rating_data_for(lo: int, hi: int) -> str:
     """Encode a rating range as the string darktable's RATING-rule data field expects."""
@@ -875,15 +880,15 @@ def _luacmd_collect_rating(data: str) -> str:
     """
     return (
         'local dt = require("darktable"); '
-        'local r = dt.gui.libs.collect.new_rule(); '
+        "local r = dt.gui.libs.collect.new_rule(); "
         'r.item = "DT_COLLECTION_PROP_RATING"; '
         'r.mode = "DT_LIB_COLLECT_MODE_AND"; '
         f'r.data = "{data}"; '
-        'dt.gui.libs.collect.filter({r})'
+        "dt.gui.libs.collect.filter({r})"
     )
 
 
-def _build_filter_luacmd(lo: int, hi: int) -> Optional[str]:
+def _build_filter_luacmd(lo: int, hi: int) -> str | None:
     """Generate a --luacmd snippet that pre-applies the rating filter.
 
     Returns None when no rule is needed (full range -1..5).
@@ -898,11 +903,11 @@ def _build_filter_luacmd(lo: int, hi: int) -> Optional[str]:
 
 def build_darktable_command(
     source_dir: str | Path,
-    rating: Optional[int] = None,
-    rating_min: Optional[int] = None,
-    rating_max: Optional[int] = None,
+    rating: int | None = None,
+    rating_min: int | None = None,
+    rating_max: int | None = None,
     darktable_path: str = "darktable",
-) -> List[str]:
+) -> list[str]:
     """Build the ``darktable`` command line for opening a folder.
 
     The folder is registered as a film roll on first launch and any XMP
@@ -925,11 +930,14 @@ def build_darktable_command(
 
     rating_range = _normalize_rating_range(rating, rating_min, rating_max)
 
-    cmd: List[str] = [
+    cmd: list[str] = [
         darktable_path,
-        "--conf", "plugins/lighttable/collect/num_rules=1",
-        "--conf", f"plugins/lighttable/collect/item0={_DT_PROP_FILMROLL}",
-        "--conf", "plugins/lighttable/collect/string0=%",
+        "--conf",
+        "plugins/lighttable/collect/num_rules=1",
+        "--conf",
+        f"plugins/lighttable/collect/item0={_DT_PROP_FILMROLL}",
+        "--conf",
+        "plugins/lighttable/collect/string0=%",
     ]
 
     if rating_range is not None:
@@ -961,7 +969,7 @@ _LOCK_SIGNATURES = (
 )
 
 
-def _drain_in_background(proc: Any, sink: Optional[List[str]] = None) -> None:
+def _drain_in_background(proc: Any, sink: list[str] | None = None) -> None:
     """Consume a live child's stdout/stderr on daemon threads.
 
     Keeps the pipes readable without ever blocking the child on a full pipe
@@ -1007,7 +1015,7 @@ def _looks_blocked_by_lock(text: str) -> bool:
     return any(sig in lowered for sig in _LOCK_SIGNATURES)
 
 
-def _wait_for_launch(proc: Any, sink: Optional[List[str]] = None) -> Optional[int]:
+def _wait_for_launch(proc: Any, sink: list[str] | None = None) -> int | None:
     """Poll a freshly spawned process briefly.
 
     Returns its exit code, or None if still alive. Stops early once the
@@ -1015,7 +1023,7 @@ def _wait_for_launch(proc: Any, sink: Optional[List[str]] = None) -> Optional[in
     does not cost the full probe window.
     """
     deadline = time.monotonic() + _LAUNCH_PROBE_SECONDS
-    code: Optional[int] = proc.poll()
+    code: int | None = proc.poll()
     while code is None and time.monotonic() < deadline:
         if sink is not None and _looks_blocked_by_lock("".join(sink)):
             break
@@ -1026,12 +1034,12 @@ def _wait_for_launch(proc: Any, sink: Optional[List[str]] = None) -> Optional[in
 
 def open_in_darktable(
     source_dir: str | Path,
-    rating: Optional[int] = None,
-    rating_min: Optional[int] = None,
-    rating_max: Optional[int] = None,
+    rating: int | None = None,
+    rating_min: int | None = None,
+    rating_max: int | None = None,
     darktable_path: str = "darktable",
     dry_run: bool = False,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Spawn darktable on ``source_dir``, pre-applying a rating filter.
 
     Opening a folder via the CLI registers it as a film roll on first launch,
@@ -1106,7 +1114,7 @@ def open_in_darktable(
     # Start draining immediately: darktable is chatty at startup (it logs every
     # bundled style it imports), and an undrained 64KB pipe buffer would block
     # the child inside our own probe window.
-    captured: List[str] = []
+    captured: list[str] = []
     _drain_in_background(proc, captured)
 
     exit_code = _wait_for_launch(proc, captured)
@@ -1153,8 +1161,7 @@ def open_in_darktable(
 
     if exit_code is not None:
         message = (
-            f"darktable exited immediately (exit code {exit_code}) instead of "
-            "staying open."
+            f"darktable exited immediately (exit code {exit_code}) instead of " "staying open."
         )
         if detail:
             message += f"\ndarktable said:\n{detail}"
@@ -1195,5 +1202,3 @@ def format_open_summary(result: Mapping[str, Any]) -> str:
                 f"supported — open the lighttable's filter bar to refine.)"
             )
     return "\n".join(lines)
-
-

--- a/examples/smoke_test_filter.py
+++ b/examples/smoke_test_filter.py
@@ -9,7 +9,6 @@ Usage: venv/bin/python examples/smoke_test_filter.py
 """
 
 import os
-import re
 import signal
 import subprocess
 import sys
@@ -54,10 +53,7 @@ def run_one_case(label: str, rating_kwargs: dict) -> tuple[bool, str]:
     # The bridge plugin is loaded; its "ready" message confirms Lua actually ran.
     bridge_ready = "darktable-mcp bridge: ready" in log_text
     # Look for LUA ERROR lines that aren't from unrelated noise.
-    lua_errors = [
-        line for line in log_text.splitlines()
-        if "LUA ERROR" in line
-    ]
+    lua_errors = [line for line in log_text.splitlines() if "LUA ERROR" in line]
     return (bridge_ready and not lua_errors, log_text if (lua_errors or not bridge_ready) else "")
 
 
@@ -74,7 +70,7 @@ def main() -> int:
         print(f"--- case: {label} ({kwargs}) ---")
         ok, log_excerpt = run_one_case(label, kwargs)
         if ok:
-            print(f"  OK")
+            print("  OK")
         else:
             failures.append((label, log_excerpt))
             print(f"  FAIL - see {LOG_PREFIX}{label}.log")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,11 +28,14 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    # Upper bound is deliberate: mcp 2.0.0 removed the @server.list_tools() /
-    # @server.call_tool() decorators from mcp.server.Server, so this server dies at
-    # startup with AttributeError under 2.x. Porting to the mcp 2.x MCPServer API is a
-    # separate follow-up; do not lift the bound before that lands.
-    "mcp>=1.9,<2",
+    # Floor is 2.0: darktable_mcp/server.py registers its tools through the mcp 2.x
+    # low-level Server(on_list_tools=..., on_call_tool=...) constructor handlers, which
+    # replaced the 1.x @server.list_tools() / @server.call_tool() decorators. Neither
+    # spelling exists in the other major, so 1.x cannot run this code.
+    # Upper bound guards the next major the same way: 2.0 already moved the wire types
+    # to mcp_types (Tool.inputSchema -> Tool.input_schema) and made handlers return
+    # ListToolsResult / CallToolResult instead of bare lists.
+    "mcp>=2,<3",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -156,9 +156,7 @@ def test_call_cleans_up_request_file_on_timeout(cache_dir, fake_plugin_lua_file)
 
 
 def test_call_cleans_up_response_file_on_success(cache_dir, fake_plugin_lua_file):
-    plugin = FakePlugin(
-        cache_dir, lambda req: {"id": req["id"], "result": "ok"}
-    )
+    plugin = FakePlugin(cache_dir, lambda req: {"id": req["id"], "result": "ok"})
     plugin.start()
     try:
         bridge = Bridge()
@@ -215,9 +213,7 @@ def test_call_applies_the_fallback_for_unknown_methods(
         bridge.call("no_such_method", {})
 
 
-def test_timeout_message_names_the_method_and_the_budget_used(
-    cache_dir, fake_plugin_lua_file
-):
+def test_timeout_message_names_the_method_and_the_budget_used(cache_dir, fake_plugin_lua_file):
     bridge = Bridge()
     with pytest.raises(BridgeTimeoutError) as exc:
         bridge.call("import_batch", {}, timeout=0.4)

--- a/tests/test_camera_tools.py
+++ b/tests/test_camera_tools.py
@@ -2,17 +2,39 @@
 
 import shutil
 import subprocess
+from contextlib import ExitStack
 from pathlib import Path
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
-from darktable_mcp.tools.camera_tools import CameraTools
+from darktable_mcp.tools.camera_tools import CameraTools, _CameraFile
 from darktable_mcp.utils.errors import DarktableMCPError
 
 #: Captured before any patching so the tests that exercise the serial probe
 #: itself can reach the real implementation past the autouse stub below.
 _REAL_PROBE_SERIAL = CameraTools._probe_serial
+#: Same trick for the file listing, whose own tests need the real thing.
+_REAL_LIST_FILES = CameraTools._list_files_in_folder
+
+
+@pytest.fixture(autouse=True)
+def _no_file_listing():
+    """Keep `gphoto2 --list-files` away from real hardware in every test.
+
+    `_download_one_folder` asks the camera what a folder holds so it can
+    decide for itself what still needs transferring. Two reasons to stub it
+    by default: an unstubbed call would talk to a camera plugged into a
+    developer machine, and — because `patch("...subprocess.Popen")` replaces
+    the attribute on the shared subprocess module — it would otherwise be
+    answered by whatever Popen mock the test installed for the *download*.
+
+    The default is "no listing available", which is the degraded path: the
+    whole folder is pulled into staging and de-duplicated by content when it
+    is placed. Tests that want the cheap path patch this themselves.
+    """
+    with patch.object(CameraTools, "_list_files_in_folder", return_value=None):
+        yield
 
 
 @pytest.fixture(autouse=True)
@@ -251,23 +273,32 @@ class TestCameraToolsDownloadOneFolder:
 
     @patch("darktable_mcp.tools.camera_tools.subprocess.Popen")
     def test_download_one_folder_success(self, mock_popen, tmp_path):
-        mock_popen.return_value = _popen_mock(
-            stdout=(
-                "Saving file as /tmp/dest/IMG_0001.NEF\n"
-                "Saving file as /tmp/dest/IMG_0002.NEF\n"
-                "Saving file as /tmp/dest/IMG_0003.NEF\n"
-            ),
+        # CHANGED (staging fix): the returned count is now files that landed
+        # in the destination, not "Saving file as" lines gphoto2 printed, so
+        # the fake has to actually write them. That is the point of the
+        # change — the old count could not tell a saved file from a claim.
+        folder = "/store_00010001/DCIM/101D800E"
+        mock_popen.side_effect = _FakeGphoto2(
+            {folder: ["IMG_0001.NEF", "IMG_0002.NEF", "IMG_0003.NEF"]}
         )
         tools = CameraTools()
         count, skipped, errors = tools._download_one_folder(
             "Nikon DSC D800E",
             "usb:002,002",
-            "/store_00010001/DCIM/101D800E",
+            folder,
             tmp_path,
             timeout_seconds=600,
         )
         assert count == 3
         assert errors == []
+        assert sorted(
+            p.name
+            for p in (tmp_path / tools._camera_folder_tag("Nikon_DSC_D800E", folder)).iterdir()
+        ) == [
+            "IMG_0001.NEF",
+            "IMG_0002.NEF",
+            "IMG_0003.NEF",
+        ]
 
         cmd = mock_popen.call_args[0][0]
         assert cmd[0] == "gphoto2"
@@ -304,17 +335,22 @@ class TestCameraToolsDownloadOneFolder:
     def test_download_one_folder_handles_mixed_formats(self, mock_popen, tmp_path):
         """gphoto2's %C placeholder gives the correct extension per file,
         so the same call copies RAW + JPEG + video without per-format logic."""
-        mock_popen.return_value = _popen_mock(
-            stdout=(
-                "Saving file as /dest/IMG_0001.NEF\n"  # Nikon RAW
-                "Saving file as /dest/IMG_0001.JPG\n"  # JPEG sidecar
-                "Saving file as /dest/IMG_0002.CR2\n"  # Canon RAW
-                "Saving file as /dest/IMG_0003.CR3\n"  # Canon RAW (newer)
-                "Saving file as /dest/IMG_0004.ARW\n"  # Sony RAW
-                "Saving file as /dest/IMG_0005.RAF\n"  # Fuji RAW
-                "Saving file as /dest/IMG_0006.DNG\n"  # Adobe / Pentax / iPhone ProRAW
-                "Saving file as /dest/MVI_0007.MP4\n"  # Video
-            ),
+        # CHANGED (staging fix): a fake that writes the files, for the same
+        # reason as test_download_one_folder_success — the count measures
+        # placement now.
+        mock_popen.side_effect = _FakeGphoto2(
+            {
+                "/": [
+                    "IMG_0001.NEF",  # Nikon RAW
+                    "IMG_0001.JPG",  # JPEG sidecar
+                    "IMG_0002.CR2",  # Canon RAW
+                    "IMG_0003.CR3",  # Canon RAW (newer)
+                    "IMG_0004.ARW",  # Sony RAW
+                    "IMG_0005.RAF",  # Fuji RAW
+                    "IMG_0006.DNG",  # Adobe / Pentax / iPhone ProRAW
+                    "MVI_0007.MP4",  # Video
+                ]
+            }
         )
         log_path = tmp_path / "progress.log"
         with open(log_path, "w", encoding="utf-8") as log:
@@ -334,10 +370,11 @@ class TestCameraToolsDownloadOneFolder:
 
     @patch("darktable_mcp.tools.camera_tools.subprocess.Popen")
     def test_download_one_folder_partial_failure(self, mock_popen, tmp_path):
-        mock_popen.return_value = _popen_mock(
-            stdout=(
-                "Saving file as /tmp/dest/IMG_0001.NEF\n" "Saving file as /tmp/dest/IMG_0002.NEF\n"
-            ),
+        # CHANGED (staging fix): same reason — the two files that did arrive
+        # have to exist for the count to see them. The third one erroring is
+        # still reported from stderr.
+        mock_popen.side_effect = _FakeGphoto2(
+            {"/": ["IMG_0001.NEF", "IMG_0002.NEF"]},
             stderr="ERROR: Could not download IMG_0003.NEF\n",
             returncode=1,
         )
@@ -418,9 +455,11 @@ class TestCameraToolsDownloadOneFolder:
 
     @patch("darktable_mcp.tools.camera_tools.subprocess.Popen")
     def test_download_one_folder_writes_progress_lines_to_log(self, mock_popen, tmp_path):
-        mock_popen.return_value = _popen_mock(
-            stdout=("Saving file as /dest/A.NEF\n" "Saving file as /dest/B.NEF\n"),
-        )
+        # CHANGED (staging fix): a writing fake, so the returned count still
+        # reflects two files. The log lines themselves are unchanged — they
+        # are still written from gphoto2's stream as the transfer happens,
+        # which is what `tail -f` depends on.
+        mock_popen.side_effect = _FakeGphoto2({"/": ["A.NEF", "B.NEF"]})
         log_path = tmp_path / "progress.log"
         with open(log_path, "w", encoding="utf-8") as log:
             count, _, _ = CameraTools()._download_one_folder(
@@ -477,9 +516,19 @@ class TestCameraToolsFolderLayout:
         # camera, because the folder path alone is generic across bodies.
         # A direct caller that passes no identity gets the model-derived
         # one — never a bare folder tag.
+        # CHANGED (staging fix): gphoto2 no longer writes into the
+        # destination at all. It writes into a private per-run directory
+        # under it, and the files are moved into `<dest>/<tag>/` afterwards
+        # by logic that can see what is already there. The tag still has to
+        # be in the path, so it is still pinned here.
         tag = "Nikon_DSC_D800E_store_00010001_DCIM_101D800E"
-        assert pattern == f"{tmp_path}/{tag}/%f.%C"
+        relative = Path(pattern).relative_to(tmp_path)
+        assert relative.parts[0] == CameraTools.STAGING_DIR_NAME
+        assert relative.parts[2] == tag
+        assert pattern.endswith("%f.%C")
         assert (tmp_path / tag).is_dir()
+        # And the staging directory does not survive the call.
+        assert not (tmp_path / CameraTools.STAGING_DIR_NAME).exists()
 
     @patch("darktable_mcp.tools.camera_tools.subprocess.Popen")
     def test_root_fallback_pattern_uses_camera_folder_placeholder(self, mock_popen, tmp_path):
@@ -495,7 +544,15 @@ class TestCameraToolsFolderLayout:
         # CHANGED (camera-identity fix): the recursive-fallback directory is
         # per-camera too, so two bodies falling back on the same day do not
         # both pour into <dest>/camera/.
-        assert pattern == (f"{tmp_path}/Nikon_DSC_D800E_{CameraTools.ROOT_FOLDER_TAG}/%F/%f.%C")
+        # CHANGED (staging fix): that directory is now reached in two steps,
+        # via staging. %F is still in the pattern — the recursion must not
+        # flatten two camera folders onto each other inside staging either,
+        # and the relative tree is preserved when the files are placed.
+        tag = f"Nikon_DSC_D800E_{CameraTools.ROOT_FOLDER_TAG}"
+        relative = Path(pattern).relative_to(tmp_path)
+        assert relative.parts[0] == CameraTools.STAGING_DIR_NAME
+        assert relative.parts[2] == tag
+        assert pattern.endswith("%F/%f.%C")
 
 
 class _FakeGphoto2:
@@ -505,10 +562,21 @@ class _FakeGphoto2:
     `%f` / `%C` / `%F` placeholders the same way gphoto2 does and writes one
     file per photo in that camera folder. `--skip-existing` is honoured per
     resolved target path — which is exactly the mechanism that used to eat
-    photos when every folder resolved into the same directory.
+    photos when every folder resolved into the same directory, and which the
+    fix demotes to a same-run guard inside a private staging directory.
+
+    Also answers `--list-files` (via the `run` method, wired to
+    `subprocess.run`) and honours `--get-file <range>`, so a test can watch
+    the tool fetch *some* of a folder instead of all of it. `fetched` records
+    every filename the fake was actually asked to transfer, which is how the
+    cheap-resume tests prove that nothing came down the wire.
     """
 
-    def __init__(self, tree, marker=""):
+    #: Every photo is this many bytes unless `sizes` says otherwise. Two
+    #: bodies' `DSC_0001.NEF` are the same length on purpose.
+    DEFAULT_SIZE = 64
+
+    def __init__(self, tree, marker="", sizes=None, stderr="", returncode=0, refuse=()):
         """Build a fake camera.
 
         Args:
@@ -518,18 +586,66 @@ class _FakeGphoto2:
                 different photos at byte-identical camera paths — the file
                 bodies differ while the byte size stays the same, which is
                 the shape that defeats every size-based comparison.
+            sizes: optional filename -> byte size overrides.
+            stderr: stderr text for the download invocation.
+            returncode: exit status for the download invocation.
+            refuse: filenames the camera lists but will not hand over, i.e.
+                a read error on one photo of an otherwise healthy card.
         """
         self.tree = tree
         self.marker = marker
+        self.sizes = sizes or {}
+        self.stderr = stderr
+        self.returncode = returncode
+        self.refuse = set(refuse)
         self.calls = []
+        self.fetched = []
+
+    def _size(self, name):
+        return self.sizes.get(name, self.DEFAULT_SIZE)
+
+    def _body(self, folder, name):
+        return f"{self.marker}{folder}/{name}".ljust(self._size(name))[: self._size(name)]
+
+    @staticmethod
+    def _selected(cmd, count):
+        """Which 1-based file numbers this invocation asks for."""
+        if "--get-all-files" in cmd:
+            return list(range(1, count + 1))
+        spec = cmd[cmd.index("--get-file") + 1]
+        wanted = []
+        for span in spec.split(","):
+            if "-" in span:
+                first, last = span.split("-")
+                wanted.extend(range(int(first), int(last) + 1))
+            else:
+                wanted.append(int(span))
+        return wanted
+
+    def run(self, cmd, **kwargs):
+        """`subprocess.run` side effect: answers `--list-files`."""
+        self.calls.append(cmd)
+        folder = cmd[cmd.index("--folder") + 1]
+        names = self.tree.get(folder, [])
+        lines = [f"There are {len(names)} files in folder '{folder}'.\n"]
+        for position, name in enumerate(names, start=1):
+            # Mirrors gphoto2's own columns, including its whole-KB sizes.
+            lines.append(
+                f"#{position:<5} {name:<27} rd  {self._size(name) // 1024} KB image/x-raw\n"
+            )
+        return Mock(returncode=0, stdout="".join(lines), stderr="")
 
     def __call__(self, cmd, **kwargs):
         self.calls.append(cmd)
         folder = cmd[cmd.index("--folder") + 1]
         pattern = cmd[cmd.index("--filename") + 1]
         skip_existing = "--skip-existing" in cmd
+        names = self.tree.get(folder, [])
         lines = []
-        for name in self.tree.get(folder, []):
+        for position in self._selected(cmd, len(names)):
+            name = names[position - 1]
+            if name in self.refuse:
+                continue
             stem, _, ext = name.rpartition(".")
             target = Path(
                 pattern.replace("%F", folder.strip("/")).replace("%f", stem).replace("%C", ext)
@@ -538,10 +654,10 @@ class _FakeGphoto2:
                 lines.append(f"Skip existing file {target}\n")
                 continue
             target.parent.mkdir(parents=True, exist_ok=True)
-            # Same byte length for both cards' DSC_0001.NEF on purpose.
-            target.write_text(f"{self.marker}{folder}/{name}"[:64].ljust(64))
+            target.write_text(self._body(folder, name))
+            self.fetched.append(name)
             lines.append(f"Saving file as {target}\n")
-        return _popen_mock(stdout="".join(lines))
+        return _popen_mock(stdout="".join(lines), stderr=self.stderr, returncode=self.returncode)
 
 
 class TestCameraToolsNoFilenameCollisions:
@@ -1863,3 +1979,481 @@ class TestCameraToolsImportReportsNameConflicts:
         mock_download.return_value = (5, 0, [])
         summary = CameraTools().import_from_camera({"destination": str(tmp_path)})
         assert "name conflict" not in summary
+
+
+def _run_ptp_import(
+    fake,
+    destination,
+    folders,
+    model="Nikon D850",
+    port="usb:002,002",
+    serial=None,
+    tools=None,
+    expected=None,
+):
+    """Drive one whole PTP import against a fake camera.
+
+    Wires the fake to both halves of the gphoto2 CLI — `subprocess.run` for
+    `--list-files`, `subprocess.Popen` for the transfers — and restores the
+    real `_list_files_in_folder`, which the autouse fixture stubs out. The
+    folder walk and the `--num-files` pre-flight are stubbed because they
+    would otherwise be answered by the same `subprocess.run` mock.
+
+    Args:
+        fake: a `_FakeGphoto2`.
+        destination: import root.
+        folders: what `_list_image_folders` should report.
+        model: gphoto2 model string.
+        port: gphoto2 port string.
+        serial: what the body reports for `serialnumber`. None is the
+            interesting case — that is the body that cannot be told apart
+            from another of the same model.
+        tools: reuse an existing CameraTools instance if given.
+        expected: what `--num-files` reports per folder.
+
+    Returns:
+        Whatever `_download_from_camera` returns.
+    """
+    tools = tools or CameraTools()
+    patches = [
+        patch.object(CameraTools, "_list_image_folders", return_value=folders),
+        patch.object(CameraTools, "_count_files_in_folder", return_value=expected),
+        patch.object(CameraTools, "_list_files_in_folder", _REAL_LIST_FILES),
+        patch.object(CameraTools, "_probe_serial", return_value=serial),
+        patch("darktable_mcp.tools.camera_tools.subprocess.run", side_effect=fake.run),
+        patch("darktable_mcp.tools.camera_tools.subprocess.Popen", side_effect=fake),
+    ]
+    with ExitStack() as stack:
+        for item in patches:
+            stack.enter_context(item)
+        return tools._download_from_camera(model, port, destination)
+
+
+def _transfer_calls(fake):
+    """The gphoto2 invocations that actually moved data off the camera."""
+    return [c for c in fake.calls if "--get-all-files" in c or "--get-file" in c]
+
+
+class TestCameraToolsListFilesParsing:
+    """`--list-files` is the resume mechanism now, so its parser is load-bearing."""
+
+    @patch("darktable_mcp.tools.camera_tools.subprocess.run")
+    def test_parses_gphoto2_columns_including_kilobyte_sizes(self, mock_run):
+        mock_run.return_value = Mock(
+            returncode=0,
+            stdout=(
+                "There are 2 files in folder '/store_00010001/DCIM/100NCD80'.\n"
+                "#1     DSC_0001.NEF               rd  9863 KB image/x-nikon-nef\n"
+                "#2     DSC_0002.NEF               rd  9871 KB image/x-nikon-nef\n"
+            ),
+            stderr="",
+        )
+        entries = _REAL_LIST_FILES(
+            CameraTools(), "Nikon D850", "usb:002,002", "/store_00010001/DCIM/100NCD80"
+        )
+        assert [(e.number, e.name, e.size_kb) for e in entries] == [
+            (1, "DSC_0001.NEF", 9863),
+            (2, "DSC_0002.NEF", 9871),
+        ]
+        cmd = mock_run.call_args[0][0]
+        assert "--list-files" in cmd
+        assert "/store_00010001/DCIM/100NCD80" in cmd
+
+    @patch("darktable_mcp.tools.camera_tools.subprocess.run")
+    def test_raw_byte_sizes_are_normalised_to_kilobytes(self, mock_run):
+        # Not every build prints KB. A bare byte count must not be read as
+        # kilobytes, or every size compare would be off by a factor of 1024
+        # and nothing would ever be recognised as already copied.
+        mock_run.return_value = Mock(
+            returncode=0,
+            stdout="#1     IMG_0001.JPG               rd  2097152 image/jpeg\n",
+            stderr="",
+        )
+        entries = _REAL_LIST_FILES(CameraTools(), "Some Camera", "usb:001,001", "/")
+        assert entries[0].size_kb == 2048
+
+    @patch("darktable_mcp.tools.camera_tools.subprocess.run")
+    def test_line_without_a_size_yields_unknown_not_zero(self, mock_run):
+        mock_run.return_value = Mock(
+            returncode=0,
+            stdout="#1     DSC_0001.NEF               rd  image/x-nikon-nef\n",
+            stderr="",
+        )
+        entries = _REAL_LIST_FILES(CameraTools(), "Nikon D850", "usb:002,002", "/x")
+        assert entries[0].size_kb is None
+
+    @patch("darktable_mcp.tools.camera_tools.subprocess.run")
+    def test_nonzero_exit_degrades_to_none(self, mock_run):
+        mock_run.return_value = Mock(returncode=1, stdout="", stderr="*** Error ***\n")
+        assert _REAL_LIST_FILES(CameraTools(), "Nikon D850", "usb:002,002", "/x") is None
+
+    @patch("darktable_mcp.tools.camera_tools.subprocess.run")
+    def test_unparseable_output_degrades_to_none(self, mock_run):
+        mock_run.return_value = Mock(returncode=0, stdout="weird output\n", stderr="")
+        assert _REAL_LIST_FILES(CameraTools(), "Nikon D850", "usb:002,002", "/x") is None
+
+    @patch("darktable_mcp.tools.camera_tools.subprocess.run")
+    def test_missing_binary_degrades_instead_of_raising(self, mock_run):
+        # Like the serial probe: the listing is an optimisation, and losing
+        # it must cost speed, not the import.
+        mock_run.side_effect = FileNotFoundError("gphoto2")
+        assert _REAL_LIST_FILES(CameraTools(), "Nikon D850", "usb:002,002", "/x") is None
+
+    @patch("darktable_mcp.tools.camera_tools.subprocess.run")
+    def test_timeout_degrades_to_none(self, mock_run):
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd=["gphoto2"], timeout=60)
+        assert _REAL_LIST_FILES(CameraTools(), "Nikon D850", "usb:002,002", "/x") is None
+
+
+class TestCameraToolsRangeExpression:
+    """`--get-file` takes gphoto2's RANGE syntax; a wrong range fetches wrong files."""
+
+    def test_consecutive_numbers_collapse_into_a_span(self):
+        assert CameraTools._range_expression([1, 2, 3]) == "1-3"
+
+    def test_gaps_are_preserved(self):
+        assert CameraTools._range_expression([1, 3, 4, 5, 9]) == "1,3-5,9"
+
+    def test_unordered_input_is_sorted_and_deduplicated(self):
+        assert CameraTools._range_expression([5, 1, 5, 2]) == "1-2,5"
+
+    def test_empty_selection_is_empty(self):
+        assert CameraTools._range_expression([]) == ""
+
+
+class TestCameraToolsIdentityStrength:
+    """Only a serial number makes an identity unique to one physical body."""
+
+    def test_serial_identity_is_unique(self):
+        assert CameraTools._identity_is_body_unique("Nikon_D850_sn_30014567") is True
+
+    def test_model_only_identity_is_not_unique(self):
+        assert CameraTools._identity_is_body_unique("Nikon_D850") is False
+
+    def test_empty_identity_is_not_unique(self):
+        assert CameraTools._identity_is_body_unique("") is False
+
+    def test_a_model_word_spelled_sn_is_not_a_serial(self):
+        # `_model_tag` upper-cases nothing, but model words arrive as the
+        # camera spells them. The marker this checks for is the literal
+        # lower-case `sn_` prefix `_camera_identity` writes.
+        assert CameraTools._identity_is_body_unique("Canon_SN_5") is False
+
+
+class TestCameraToolsDestinationHolds:
+    """The cheap "already there?" test: name plus a kilobyte-granular size."""
+
+    def _entry(self, name="DSC_0001.NEF", number=1, size_kb=0):
+        return _CameraFile(number=number, name=name, size_kb=size_kb)
+
+    def test_missing_name_is_not_held(self, tmp_path):
+        assert CameraTools._destination_holds(tmp_path, self._entry()) is False
+
+    def test_matching_name_and_size_is_held(self, tmp_path):
+        (tmp_path / "DSC_0001.NEF").write_bytes(b"x" * 2048)
+        assert CameraTools._destination_holds(tmp_path, self._entry(size_kb=2)) is True
+
+    def test_same_name_very_different_size_is_not_held(self, tmp_path):
+        (tmp_path / "DSC_0001.NEF").write_bytes(b"x" * 2048)
+        assert CameraTools._destination_holds(tmp_path, self._entry(size_kb=9000)) is False
+
+    def test_a_previous_conflict_copy_counts_as_holding_it(self, tmp_path):
+        # The second body's photo lives under -2. Without this, that body
+        # would re-fetch its whole card on every resume and grow a -3.
+        (tmp_path / "DSC_0001.NEF").write_bytes(b"a" * 2048)
+        (tmp_path / "DSC_0001-2.NEF").write_bytes(b"b" * 4096)
+        assert CameraTools._destination_holds(tmp_path, self._entry(size_kb=4)) is True
+
+    def test_unknown_size_falls_back_to_the_name(self, tmp_path):
+        (tmp_path / "DSC_0001.NEF").write_bytes(b"x" * 2048)
+        assert CameraTools._destination_holds(tmp_path, self._entry(size_kb=None)) is True
+
+
+class TestCameraToolsPtpNeverLosesAPhoto:
+    """The gap this change closes: two bodies, one destination, PTP.
+
+    Two Nikons of the same model that report no serial number resolve to the
+    same identity, so they share a destination subdirectory. Their photos
+    share names *and* sizes. gphoto2's `--skip-existing` compared nothing but
+    the path, so the second body's DSC_0001.NEF was dropped inside gphoto2's
+    own process with no error and a destination that looked complete.
+    """
+
+    FOLDER = "/store_00010001/DCIM/100NCD80"
+    FOLDERS = [FOLDER]
+    TREE = {FOLDER: ["DSC_0001.NEF", "DSC_0002.NEF"]}
+    TAG = "Nikon_D850_store_00010001_DCIM_100NCD80"
+
+    def _body(self, marker):
+        return _FakeGphoto2(self.TREE, marker=marker)
+
+    def test_second_body_with_the_same_names_and_sizes_keeps_both_photos(self, tmp_path):
+        first = self._body("A")
+        saved, skipped, errors = _run_ptp_import(first, tmp_path, self.FOLDERS)
+        assert (saved, skipped) == (2, 0)
+
+        second = self._body("B")
+        saved, skipped, errors = _run_ptp_import(second, tmp_path, self.FOLDERS)
+
+        assert saved == 2, "the second body's photos must not be skipped"
+        assert skipped == 0
+        landed = sorted(p.name for p in (tmp_path / self.TAG).iterdir())
+        assert landed == [
+            "DSC_0001-2.NEF",
+            "DSC_0001.NEF",
+            "DSC_0002-2.NEF",
+            "DSC_0002.NEF",
+        ]
+        bodies = {p.read_text() for p in (tmp_path / self.TAG).iterdir()}
+        assert len(bodies) == 4, "four genuinely different photos are on disk"
+        renames = [e for e in errors if e.startswith(CameraTools.RENAMED_PREFIX)]
+        assert len(renames) == 2, "the user is told which files were renamed"
+        assert not [e for e in errors if e.startswith(CameraTools.SHORTFALL_PREFIX)]
+
+    def test_the_second_body_resumes_cheaply_and_does_not_grow_a_third_copy(self, tmp_path):
+        _run_ptp_import(self._body("A"), tmp_path, self.FOLDERS)
+        _run_ptp_import(self._body("B"), tmp_path, self.FOLDERS)
+
+        again = self._body("B")
+        saved, skipped, errors = _run_ptp_import(again, tmp_path, self.FOLDERS)
+
+        assert saved == 0
+        assert skipped == 2
+        assert len(list((tmp_path / self.TAG).iterdir())) == 4, "no -3 copies"
+        # Cheap: only the identity sample came down the wire, not the folder.
+        assert sorted(again.fetched) == ["DSC_0001.NEF", "DSC_0002.NEF"]
+
+    def test_the_first_body_still_resumes_without_being_confused_by_the_second(self, tmp_path):
+        _run_ptp_import(self._body("A"), tmp_path, self.FOLDERS)
+        _run_ptp_import(self._body("B"), tmp_path, self.FOLDERS)
+
+        again = self._body("A")
+        saved, skipped, _errors = _run_ptp_import(again, tmp_path, self.FOLDERS)
+        assert (saved, skipped) == (0, 2)
+        assert len(list((tmp_path / self.TAG).iterdir())) == 4
+
+    def test_the_conflict_is_reported_in_the_import_summary(self, tmp_path):
+        _run_ptp_import(self._body("A"), tmp_path, self.FOLDERS)
+        second = self._body("B")
+        with patch.object(
+            CameraTools,
+            "_detect_cameras",
+            return_value=[{"model": "Nikon D850", "port": "usb:002,002"}],
+        ):
+            patches = [
+                patch.object(CameraTools, "_list_image_folders", return_value=self.FOLDERS),
+                patch.object(CameraTools, "_count_files_in_folder", return_value=None),
+                patch.object(CameraTools, "_list_files_in_folder", _REAL_LIST_FILES),
+                patch("darktable_mcp.tools.camera_tools.subprocess.run", side_effect=second.run),
+                patch("darktable_mcp.tools.camera_tools.subprocess.Popen", side_effect=second),
+            ]
+            with ExitStack() as stack:
+                for item in patches:
+                    stack.enter_context(item)
+                summary = CameraTools().import_from_camera({"destination": str(tmp_path)})
+        assert "Kept both copies for 2 name conflict(s)" in summary
+        assert "DSC_0001-2.NEF" in summary
+
+
+class TestCameraToolsPtpResumeStaysCheap:
+    """Requirement two: an ordinary re-run must not re-read the card."""
+
+    FOLDER = "/store_00010001/DCIM/100NCD80"
+    FOLDERS = [FOLDER]
+    TREE = {FOLDER: [f"DSC_{n:04d}.NEF" for n in range(1, 6)]}
+    TAG_NO_SERIAL = "Nikon_D850_store_00010001_DCIM_100NCD80"
+    TAG_SERIAL = "Nikon_D850_sn_30014567_store_00010001_DCIM_100NCD80"
+
+    def test_a_body_with_a_serial_number_transfers_nothing_on_a_re_run(self, tmp_path):
+        first = _FakeGphoto2(self.TREE, marker="A")
+        _run_ptp_import(first, tmp_path, self.FOLDERS, serial="30014567")
+        before = sorted(p.name for p in (tmp_path / self.TAG_SERIAL).iterdir())
+
+        again = _FakeGphoto2(self.TREE, marker="A")
+        saved, skipped, errors = _run_ptp_import(again, tmp_path, self.FOLDERS, serial="30014567")
+
+        assert (saved, skipped) == (0, 5)
+        assert errors == []
+        assert again.fetched == [], "a serial number makes the directory provably this body's"
+        assert _transfer_calls(again) == [], "gphoto2 was not even asked to transfer"
+        assert sorted(p.name for p in (tmp_path / self.TAG_SERIAL).iterdir()) == before
+
+    def test_a_body_without_a_serial_pays_only_the_bounded_sample(self, tmp_path):
+        _run_ptp_import(_FakeGphoto2(self.TREE, marker="A"), tmp_path, self.FOLDERS)
+
+        again = _FakeGphoto2(self.TREE, marker="A")
+        saved, skipped, errors = _run_ptp_import(again, tmp_path, self.FOLDERS)
+
+        assert (saved, skipped) == (0, 5)
+        assert errors == []
+        assert len(again.fetched) == CameraTools.PROBE_SAMPLE_SIZE
+        assert len(list((tmp_path / self.TAG_NO_SERIAL).iterdir())) == 5
+
+    def test_resume_produces_the_same_paths_twice(self, tmp_path):
+        _run_ptp_import(_FakeGphoto2(self.TREE, marker="A"), tmp_path, self.FOLDERS)
+        first = sorted(str(p.relative_to(tmp_path)) for p in tmp_path.rglob("*.NEF"))
+        _run_ptp_import(_FakeGphoto2(self.TREE, marker="A"), tmp_path, self.FOLDERS)
+        second = sorted(str(p.relative_to(tmp_path)) for p in tmp_path.rglob("*.NEF"))
+        assert first == second
+        assert not (tmp_path / CameraTools.STAGING_DIR_NAME).exists()
+
+    def test_only_the_new_photos_are_fetched_after_more_shooting(self, tmp_path):
+        _run_ptp_import(
+            _FakeGphoto2(self.TREE, marker="A"), tmp_path, self.FOLDERS, serial="30014567"
+        )
+
+        grown = dict(self.TREE)
+        grown[self.FOLDER] = self.TREE[self.FOLDER] + ["DSC_0006.NEF", "DSC_0007.NEF"]
+        again = _FakeGphoto2(grown, marker="A")
+        saved, skipped, _errors = _run_ptp_import(again, tmp_path, self.FOLDERS, serial="30014567")
+
+        assert (saved, skipped) == (2, 5)
+        assert again.fetched == ["DSC_0006.NEF", "DSC_0007.NEF"]
+        # Fetched by number, as a range, rather than pulling the folder.
+        transfer = _transfer_calls(again)[0]
+        assert "--get-file" in transfer
+        assert transfer[transfer.index("--get-file") + 1] == "6-7"
+
+
+class TestCameraToolsPtpTellsTheUserWhatDidNotArrive:
+    """Requirement one: no photo goes missing without the user hearing it."""
+
+    FOLDER = "/store_00010001/DCIM/100NCD80"
+    FOLDERS = [FOLDER]
+    TREE = {FOLDER: ["DSC_0001.NEF", "DSC_0002.NEF", "DSC_0003.NEF"]}
+
+    def test_a_file_the_camera_refuses_to_send_is_named_in_the_errors(self, tmp_path):
+        fake = _FakeGphoto2(self.TREE, marker="A", refuse=["DSC_0002.NEF"])
+        saved, _skipped, errors = _run_ptp_import(fake, tmp_path, self.FOLDERS)
+
+        assert saved == 2
+        shortfalls = [e for e in errors if e.startswith(CameraTools.SHORTFALL_PREFIX)]
+        assert shortfalls, "a file that never arrived must be reported"
+        assert "DSC_0002.NEF" in shortfalls[0]
+
+    def test_a_clean_import_reports_no_shortfall(self, tmp_path):
+        fake = _FakeGphoto2(self.TREE, marker="A")
+        _saved, _skipped, errors = _run_ptp_import(fake, tmp_path, self.FOLDERS)
+        assert errors == []
+
+    def test_files_that_cannot_be_placed_are_kept_and_reported(self, tmp_path):
+        # The failure mode the staging design introduces: a download that
+        # succeeds but cannot be moved into place. The file must not be
+        # thrown away with the staging directory.
+        fake = _FakeGphoto2(self.TREE, marker="A")
+        with patch.object(
+            CameraTools, "_never_overwrite_target", side_effect=OSError("read-only file system")
+        ):
+            saved, _skipped, errors = _run_ptp_import(fake, tmp_path, self.FOLDERS)
+
+        assert saved == 0
+        shortfalls = [e for e in errors if e.startswith(CameraTools.SHORTFALL_PREFIX)]
+        assert any("could not be moved" in e for e in shortfalls)
+        staged = sorted(p.name for p in (tmp_path / CameraTools.STAGING_DIR_NAME).rglob("*.NEF"))
+        assert staged == ["DSC_0001.NEF", "DSC_0002.NEF", "DSC_0003.NEF"]
+
+    def test_an_unreadable_sample_forces_a_full_fetch_instead_of_a_skip(self, tmp_path):
+        # If the camera cannot re-send the sample, nothing has been proven,
+        # so nothing may be skipped: fetch everything and let placement
+        # decide by content.
+        _run_ptp_import(_FakeGphoto2(self.TREE, marker="A"), tmp_path, self.FOLDERS)
+
+        again = _FakeGphoto2(self.TREE, marker="A", refuse=self.TREE[self.FOLDER])
+        saved, skipped, _errors = _run_ptp_import(again, tmp_path, self.FOLDERS)
+        assert saved == 0
+        assert skipped == 0, "nothing was proven, so nothing was counted as skipped"
+        assert _transfer_calls(again), "the folder was re-requested rather than trusted"
+
+
+class TestCameraToolsPtpSampleIsBounded:
+    """The hole that is left, pinned so it cannot be quietly forgotten."""
+
+    FOLDER = "/store_00010001/DCIM/100NCD80"
+    FOLDERS = [FOLDER]
+    NAMES = [f"DSC_{n:04d}.NEF" for n in range(1, 9)]
+    TREE = {FOLDER: NAMES}
+    TAG = "Nikon_D850_store_00010001_DCIM_100NCD80"
+
+    class _PartlyIdenticalBody(_FakeGphoto2):
+        """A second body whose sampled photos happen to be byte-identical."""
+
+        DIFFERENT = "DSC_0004.NEF"
+
+        def _body(self, folder, name):
+            marker = self.marker if name == self.DIFFERENT else ""
+            return f"{marker}{folder}/{name}".ljust(self._size(name))[: self._size(name)]
+
+    def test_a_difference_outside_the_sample_is_not_detected(self, tmp_path):
+        _run_ptp_import(self._PartlyIdenticalBody(self.TREE, marker=""), tmp_path, self.FOLDERS)
+        second = self._PartlyIdenticalBody(self.TREE, marker="B")
+        saved, skipped, _errors = _run_ptp_import(second, tmp_path, self.FOLDERS)
+
+        # Documented in the CameraTools docstring: the sample is bounded, so
+        # a second body that matches on every sampled file is taken to be
+        # the same body and its differing photo is skipped. Closing this
+        # would mean downloading every file on every run.
+        assert (saved, skipped) == (0, 8)
+        assert len(list((tmp_path / self.TAG).iterdir())) == 8
+        assert len(second.fetched) == CameraTools.PROBE_SAMPLE_SIZE
+
+    def test_a_folder_no_bigger_than_the_sample_is_checked_exhaustively(self, tmp_path):
+        small = {self.FOLDER: self.NAMES[: CameraTools.PROBE_SAMPLE_SIZE]}
+        _run_ptp_import(_FakeGphoto2(small, marker="A"), tmp_path, self.FOLDERS)
+        second = _FakeGphoto2(small, marker="B")
+        saved, _skipped, _errors = _run_ptp_import(second, tmp_path, self.FOLDERS)
+        assert saved == CameraTools.PROBE_SAMPLE_SIZE
+        assert len(list((tmp_path / self.TAG).iterdir())) == 2 * CameraTools.PROBE_SAMPLE_SIZE
+
+
+class TestCameraToolsStagingHousekeeping:
+    """Staging is inside the destination, so it must never be counted or left."""
+
+    def test_staged_files_are_not_counted_as_imported(self, tmp_path):
+        (tmp_path / "Nikon_D850_a").mkdir()
+        (tmp_path / "Nikon_D850_a" / "DSC_0001.NEF").write_bytes(b"x")
+        staged = tmp_path / CameraTools.STAGING_DIR_NAME / "123-abc" / "Nikon_D850_a"
+        staged.mkdir(parents=True)
+        (staged / "DSC_0002.NEF").write_bytes(b"y")
+        assert CameraTools()._count_files_on_disk(tmp_path) == 1
+
+    def test_a_finished_folder_leaves_no_staging_directory(self, tmp_path):
+        folder = "/store_00010001/DCIM/100NCD80"
+        fake = _FakeGphoto2({folder: ["DSC_0001.NEF"]}, marker="A")
+        _run_ptp_import(fake, tmp_path, [folder])
+        assert not (tmp_path / CameraTools.STAGING_DIR_NAME).exists()
+
+    def test_a_timeout_places_what_arrived_and_drops_the_truncated_file(self, tmp_path):
+        # gphoto2 announces a file before writing it, so the last announced
+        # file is the one that was in flight when the clock ran out. Placing
+        # it would put a truncated photo in the destination under the real
+        # name, where the next run would find it and keep it forever.
+        folder = "/store_00010001/DCIM/100NCD80"
+        tag = "Nikon_D850_store_00010001_DCIM_100NCD80"
+
+        def _side_effect(cmd, **kwargs):
+            pattern = cmd[cmd.index("--filename") + 1]
+            base = Path(pattern.replace("%f.%C", ""))
+            base.mkdir(parents=True, exist_ok=True)
+            lines = []
+            for name, content in (
+                ("DSC_0001.NEF", "complete-1".ljust(64)),
+                ("DSC_0002.NEF", "complete-2".ljust(64)),
+                ("DSC_0003.NEF", "trunc"),
+            ):
+                (base / name).write_text(content)
+                lines.append(f"Saving file as {base / name}\n")
+            return _popen_mock(stdout="".join(lines), raises_timeout=True)
+
+        with pytest.raises(subprocess.TimeoutExpired):
+            with patch(
+                "darktable_mcp.tools.camera_tools.subprocess.Popen", side_effect=_side_effect
+            ):
+                CameraTools()._download_one_folder(
+                    "Nikon D850", "usb:002,002", folder, tmp_path, timeout_seconds=1
+                )
+
+        assert sorted(p.name for p in (tmp_path / tag).iterdir()) == [
+            "DSC_0001.NEF",
+            "DSC_0002.NEF",
+        ]
+        assert not (tmp_path / CameraTools.STAGING_DIR_NAME).exists()

--- a/tests/test_camera_tools.py
+++ b/tests/test_camera_tools.py
@@ -197,9 +197,7 @@ class TestCameraToolsListImageFolders:
 
     @patch("darktable_mcp.tools.camera_tools.subprocess.run")
     def test_list_dual_storage_returns_three_leaves(self, mock_run):
-        mock_run.return_value = Mock(
-            returncode=0, stdout=self.DUAL_STORAGE_OUTPUT, stderr=""
-        )
+        mock_run.return_value = Mock(returncode=0, stdout=self.DUAL_STORAGE_OUTPUT, stderr="")
         leaves = CameraTools()._list_image_folders("Nikon DSC D800E", "usb:002,002")
         assert leaves == [
             "/store_00010001/DCIM/101D800E",
@@ -308,21 +306,25 @@ class TestCameraToolsDownloadOneFolder:
         so the same call copies RAW + JPEG + video without per-format logic."""
         mock_popen.return_value = _popen_mock(
             stdout=(
-                "Saving file as /dest/IMG_0001.NEF\n"   # Nikon RAW
-                "Saving file as /dest/IMG_0001.JPG\n"   # JPEG sidecar
-                "Saving file as /dest/IMG_0002.CR2\n"   # Canon RAW
-                "Saving file as /dest/IMG_0003.CR3\n"   # Canon RAW (newer)
-                "Saving file as /dest/IMG_0004.ARW\n"   # Sony RAW
-                "Saving file as /dest/IMG_0005.RAF\n"   # Fuji RAW
-                "Saving file as /dest/IMG_0006.DNG\n"   # Adobe / Pentax / iPhone ProRAW
-                "Saving file as /dest/MVI_0007.MP4\n"   # Video
+                "Saving file as /dest/IMG_0001.NEF\n"  # Nikon RAW
+                "Saving file as /dest/IMG_0001.JPG\n"  # JPEG sidecar
+                "Saving file as /dest/IMG_0002.CR2\n"  # Canon RAW
+                "Saving file as /dest/IMG_0003.CR3\n"  # Canon RAW (newer)
+                "Saving file as /dest/IMG_0004.ARW\n"  # Sony RAW
+                "Saving file as /dest/IMG_0005.RAF\n"  # Fuji RAW
+                "Saving file as /dest/IMG_0006.DNG\n"  # Adobe / Pentax / iPhone ProRAW
+                "Saving file as /dest/MVI_0007.MP4\n"  # Video
             ),
         )
         log_path = tmp_path / "progress.log"
         with open(log_path, "w", encoding="utf-8") as log:
             count, skipped, errors = CameraTools()._download_one_folder(
-                "Some Camera", "usb:001,001", "/", tmp_path,
-                timeout_seconds=60, progress_log=log,
+                "Some Camera",
+                "usb:001,001",
+                "/",
+                tmp_path,
+                timeout_seconds=60,
+                progress_log=log,
             )
         assert count == 8
         assert errors == []
@@ -334,8 +336,7 @@ class TestCameraToolsDownloadOneFolder:
     def test_download_one_folder_partial_failure(self, mock_popen, tmp_path):
         mock_popen.return_value = _popen_mock(
             stdout=(
-                "Saving file as /tmp/dest/IMG_0001.NEF\n"
-                "Saving file as /tmp/dest/IMG_0002.NEF\n"
+                "Saving file as /tmp/dest/IMG_0001.NEF\n" "Saving file as /tmp/dest/IMG_0002.NEF\n"
             ),
             stderr="ERROR: Could not download IMG_0003.NEF\n",
             returncode=1,
@@ -401,9 +402,7 @@ class TestCameraToolsDownloadOneFolder:
             )
 
     @patch("darktable_mcp.tools.camera_tools.subprocess.Popen")
-    def test_download_one_folder_skip_existing_only_is_not_lock_error(
-        self, mock_popen, tmp_path
-    ):
+    def test_download_one_folder_skip_existing_only_is_not_lock_error(self, mock_popen, tmp_path):
         # When all files already exist on disk, gphoto2 prints "Skip
         # existing" lines and may still return rc=0 (or rc=1 in some
         # versions); either way, this is not a lock error. We must NOT
@@ -420,10 +419,7 @@ class TestCameraToolsDownloadOneFolder:
     @patch("darktable_mcp.tools.camera_tools.subprocess.Popen")
     def test_download_one_folder_writes_progress_lines_to_log(self, mock_popen, tmp_path):
         mock_popen.return_value = _popen_mock(
-            stdout=(
-                "Saving file as /dest/A.NEF\n"
-                "Saving file as /dest/B.NEF\n"
-            ),
+            stdout=("Saving file as /dest/A.NEF\n" "Saving file as /dest/B.NEF\n"),
         )
         log_path = tmp_path / "progress.log"
         with open(log_path, "w", encoding="utf-8") as log:
@@ -486,9 +482,7 @@ class TestCameraToolsFolderLayout:
         assert (tmp_path / tag).is_dir()
 
     @patch("darktable_mcp.tools.camera_tools.subprocess.Popen")
-    def test_root_fallback_pattern_uses_camera_folder_placeholder(
-        self, mock_popen, tmp_path
-    ):
+    def test_root_fallback_pattern_uses_camera_folder_placeholder(self, mock_popen, tmp_path):
         # When folder enumeration failed we do one recursive pull from "/".
         # gphoto2's own %F (camera folder path) keeps that recursion from
         # flattening two folders onto each other.
@@ -501,9 +495,7 @@ class TestCameraToolsFolderLayout:
         # CHANGED (camera-identity fix): the recursive-fallback directory is
         # per-camera too, so two bodies falling back on the same day do not
         # both pour into <dest>/camera/.
-        assert pattern == (
-            f"{tmp_path}/Nikon_DSC_D800E_{CameraTools.ROOT_FOLDER_TAG}/%F/%f.%C"
-        )
+        assert pattern == (f"{tmp_path}/Nikon_DSC_D800E_{CameraTools.ROOT_FOLDER_TAG}/%F/%f.%C")
 
 
 class _FakeGphoto2:
@@ -540,9 +532,7 @@ class _FakeGphoto2:
         for name in self.tree.get(folder, []):
             stem, _, ext = name.rpartition(".")
             target = Path(
-                pattern.replace("%F", folder.strip("/"))
-                .replace("%f", stem)
-                .replace("%C", ext)
+                pattern.replace("%F", folder.strip("/")).replace("%f", stem).replace("%C", ext)
             )
             if skip_existing and target.exists():
                 lines.append(f"Skip existing file {target}\n")
@@ -602,9 +592,7 @@ class TestCameraToolsNoFilenameCollisions:
 
         # Second run over an unchanged card: nothing new, everything skipped.
         mock_popen.side_effect = _FakeGphoto2(self.TREE)
-        saved, skipped, errors = tools._download_from_camera(
-            "Nikon D850", "usb:002,002", tmp_path
-        )
+        saved, skipped, errors = tools._download_from_camera("Nikon D850", "usb:002,002", tmp_path)
         assert saved == 0
         assert skipped == 2
         assert errors == []
@@ -647,9 +635,7 @@ class TestCameraToolsOverallTimeoutBudget:
         mock_download.return_value = (1, 0, [])
         # Fake clock: 40 s elapse during the first folder.
         ticks = iter([0.0, 0.0, 40.0, 40.0])
-        monkeypatch.setattr(
-            "darktable_mcp.tools.camera_tools.time.monotonic", lambda: next(ticks)
-        )
+        monkeypatch.setattr("darktable_mcp.tools.camera_tools.time.monotonic", lambda: next(ticks))
         CameraTools()._download_from_camera(
             "Nikon DSC D800E", "usb:002,002", tmp_path, timeout_seconds=100
         )
@@ -665,9 +651,7 @@ class TestCameraToolsOverallTimeoutBudget:
         mock_list.return_value = ["/a", "/b", "/c"]
         mock_download.return_value = (2, 0, [])
         ticks = iter([0.0, 0.0, 999.0, 999.0])
-        monkeypatch.setattr(
-            "darktable_mcp.tools.camera_tools.time.monotonic", lambda: next(ticks)
-        )
+        monkeypatch.setattr("darktable_mcp.tools.camera_tools.time.monotonic", lambda: next(ticks))
         saved, _skipped, errors = CameraTools()._download_from_camera(
             "Nikon DSC D800E", "usb:002,002", tmp_path, timeout_seconds=100
         )
@@ -695,26 +679,17 @@ class TestCameraToolsCountFilesInFolder:
     @patch("darktable_mcp.tools.camera_tools.subprocess.run")
     def test_count_returns_none_on_nonzero_exit(self, mock_run):
         mock_run.return_value = Mock(returncode=1, stdout="", stderr="error")
-        assert (
-            CameraTools()._count_files_in_folder("Nikon DSC D800E", "usb:002,002", "/")
-            is None
-        )
+        assert CameraTools()._count_files_in_folder("Nikon DSC D800E", "usb:002,002", "/") is None
 
     @patch("darktable_mcp.tools.camera_tools.subprocess.run")
     def test_count_returns_none_on_unparseable_output(self, mock_run):
         mock_run.return_value = Mock(returncode=0, stdout="weird output", stderr="")
-        assert (
-            CameraTools()._count_files_in_folder("Nikon DSC D800E", "usb:002,002", "/")
-            is None
-        )
+        assert CameraTools()._count_files_in_folder("Nikon DSC D800E", "usb:002,002", "/") is None
 
     @patch("darktable_mcp.tools.camera_tools.subprocess.run")
     def test_count_returns_none_on_timeout(self, mock_run):
         mock_run.side_effect = subprocess.TimeoutExpired(cmd=["gphoto2"], timeout=30)
-        assert (
-            CameraTools()._count_files_in_folder("Nikon DSC D800E", "usb:002,002", "/")
-            is None
-        )
+        assert CameraTools()._count_files_in_folder("Nikon DSC D800E", "usb:002,002", "/") is None
 
     @patch("darktable_mcp.tools.camera_tools.subprocess.run")
     def test_count_raises_when_gphoto2_missing(self, mock_run):
@@ -729,9 +704,7 @@ class TestCameraToolsDownloadFromCamera:
     @patch.object(CameraTools, "_count_files_in_folder", return_value=None)
     @patch.object(CameraTools, "_download_one_folder")
     @patch.object(CameraTools, "_list_image_folders")
-    def test_iterates_each_storage_leaf(
-        self, mock_list, mock_download, _mock_count, tmp_path
-    ):
+    def test_iterates_each_storage_leaf(self, mock_list, mock_download, _mock_count, tmp_path):
         mock_list.return_value = [
             "/store_00010001/DCIM/101D800E",
             "/store_00020001/DCIM/101D800E",
@@ -794,16 +767,12 @@ class TestCameraToolsDownloadFromCamera:
             "Could not access camera at usb:002,002. Another process is holding it."
         )
         with pytest.raises(DarktableMCPError, match="Another process"):
-            CameraTools()._download_from_camera(
-                "Nikon DSC D800E", "usb:002,002", tmp_path
-            )
+            CameraTools()._download_from_camera("Nikon DSC D800E", "usb:002,002", tmp_path)
 
     @patch.object(CameraTools, "_count_files_in_folder", return_value=None)
     @patch.object(CameraTools, "_download_one_folder")
     @patch.object(CameraTools, "_list_image_folders")
-    def test_creates_destination(
-        self, mock_list, mock_download, _mock_count, tmp_path
-    ):
+    def test_creates_destination(self, mock_list, mock_download, _mock_count, tmp_path):
         mock_list.return_value = ["/"]
         mock_download.return_value = (0, 0, [])
         target = tmp_path / "new_dir"
@@ -847,9 +816,7 @@ class TestCameraToolsDownloadFromCamera:
         mock_list.return_value = ["/store/DCIM/101"]
         mock_count.return_value = 5
         mock_download.return_value = (5, 0, [])
-        CameraTools()._download_from_camera(
-            "Nikon DSC D800E", "usb:002,002", tmp_path
-        )
+        CameraTools()._download_from_camera("Nikon DSC D800E", "usb:002,002", tmp_path)
         log_path = tmp_path / ".import.log"
         assert log_path.exists()
         body = log_path.read_text()
@@ -893,9 +860,7 @@ class TestCameraToolsDownloadFromCamera:
     ):
         mock_list.return_value = ["/a"]
         mock_download.return_value = (0, 0, [])
-        CameraTools()._download_from_camera(
-            "Nikon DSC D800E", "usb:002,002", tmp_path
-        )
+        CameraTools()._download_from_camera("Nikon DSC D800E", "usb:002,002", tmp_path)
         # progress_log must be passed in so per-file progress can be streamed
         kwargs = mock_download.call_args.kwargs
         assert "progress_log" in kwargs
@@ -1019,9 +984,7 @@ class TestCameraToolsImportFromCamera:
 
     @patch.object(CameraTools, "_download_from_camera")
     @patch.object(CameraTools, "_detect_cameras")
-    def test_timeout_seconds_argument_flows_to_download(
-        self, mock_detect, mock_download, tmp_path
-    ):
+    def test_timeout_seconds_argument_flows_to_download(self, mock_detect, mock_download, tmp_path):
         mock_detect.return_value = [{"model": "Nikon DSC D800E", "port": "usb:002,002"}]
         mock_download.return_value = (1, 0, [])
 
@@ -1043,13 +1006,10 @@ class TestCameraToolsImportFromCamera:
 
     @patch.object(CameraTools, "_download_from_camera")
     @patch.object(CameraTools, "_detect_cameras")
-    def test_shortfall_is_prominent_in_summary(
-        self, mock_detect, mock_download, tmp_path
-    ):
+    def test_shortfall_is_prominent_in_summary(self, mock_detect, mock_download, tmp_path):
         mock_detect.return_value = [{"model": "Nikon DSC D800E", "port": "usb:002,002"}]
         shortfall = (
-            f"{CameraTools.SHORTFALL_PREFIX} 90/100 files in destination "
-            "— 10 short of expected"
+            f"{CameraTools.SHORTFALL_PREFIX} 90/100 files in destination " "— 10 short of expected"
         )
         mock_download.return_value = (90, 0, [shortfall])
         summary = CameraTools().import_from_camera({"destination": str(tmp_path)})
@@ -1062,9 +1022,7 @@ class TestCameraToolsImportFromCamera:
 
     @patch.object(CameraTools, "_download_from_camera")
     @patch.object(CameraTools, "_detect_cameras")
-    def test_partial_detect_warning_is_surfaced(
-        self, mock_detect, mock_download, tmp_path
-    ):
+    def test_partial_detect_warning_is_surfaced(self, mock_detect, mock_download, tmp_path):
         def detect(_self=None):
             tools.last_detect_warning = "gphoto2 --auto-detect exited with code 1 ..."
             return [{"model": "Nikon DSC D800E", "port": "usb:002,002"}]
@@ -1104,23 +1062,26 @@ class TestCameraToolsMSCHelpers:
         assert CameraTools._is_msc_port("") is False
 
     def test_msc_mount_strips_prefix(self):
-        assert CameraTools._msc_mount("disk:/media/user/NIKON D800E") == \
-            __import__("pathlib").Path("/media/user/NIKON D800E")
+        assert CameraTools._msc_mount("disk:/media/user/NIKON D800E") == __import__("pathlib").Path(
+            "/media/user/NIKON D800E"
+        )
 
     def test_msc_matches_ptp_for_nikon_hybrid(self):
         # The exact case from the real session: mount basename "NIKON
         # D800E" must match PTP model "Nikon DSC D800E" via shared 4+ char
         # tokens {"NIKON", "D800E"}.
-        assert CameraTools._msc_matches_ptp(
-            "disk:/media/andrii/NIKON D800E", "Nikon DSC D800E"
-        ) is True
+        assert (
+            CameraTools._msc_matches_ptp("disk:/media/andrii/NIKON D800E", "Nikon DSC D800E")
+            is True
+        )
 
     def test_msc_matches_ptp_rejects_unrelated_camera(self):
         # A Canon card in a card reader must NOT be paired with a Nikon
         # camera connected on PTP.
-        assert CameraTools._msc_matches_ptp(
-            "disk:/media/andrii/EOS_R5_DCIM", "Nikon DSC D800E"
-        ) is False
+        assert (
+            CameraTools._msc_matches_ptp("disk:/media/andrii/EOS_R5_DCIM", "Nikon DSC D800E")
+            is False
+        )
 
     def test_msc_matches_ptp_returns_false_for_non_disk_port(self):
         assert CameraTools._msc_matches_ptp("usb:002,003", "anything") is False
@@ -1182,10 +1143,13 @@ class TestCameraToolsDownloadFromMSC:
     def test_walks_dcim_subfolders_and_copies_all_files(self, tmp_path):
         mount = tmp_path / "card"
         dest = tmp_path / "out"
-        self._make_dcim(mount, {
-            "100D800E": ["DSC_0001.NEF", "DSC_0002.NEF"],
-            "101D800E": ["DSC_0003.NEF"],
-        })
+        self._make_dcim(
+            mount,
+            {
+                "100D800E": ["DSC_0001.NEF", "DSC_0002.NEF"],
+                "101D800E": ["DSC_0003.NEF"],
+            },
+        )
         saved, skipped, errors = CameraTools()._download_from_msc(mount, dest)
         assert saved == 3
         assert skipped == 0
@@ -1237,10 +1201,13 @@ class TestCameraToolsDownloadFromMSC:
         # the old `dst.exists() and same size` test threw away.
         mount = tmp_path / "card"
         dest = tmp_path / "out"
-        self._make_dcim(mount, {
-            "100NCD80": ["DSC_0001.NEF"],
-            "101NCD80": ["DSC_0001.NEF"],
-        })
+        self._make_dcim(
+            mount,
+            {
+                "100NCD80": ["DSC_0001.NEF"],
+                "101NCD80": ["DSC_0001.NEF"],
+            },
+        )
         (mount / "DCIM" / "100NCD80" / "DSC_0001.NEF").write_bytes(b"first-photo!")
         (mount / "DCIM" / "101NCD80" / "DSC_0001.NEF").write_bytes(b"second-photo")
 
@@ -1267,9 +1234,7 @@ class TestCameraToolsDownloadFromMSC:
         assert errors == []
         assert len(list(dest.rglob("*.NEF"))) == 2
 
-    def test_timeout_budget_aborts_with_partial_progress_error(
-        self, tmp_path, monkeypatch
-    ):
+    def test_timeout_budget_aborts_with_partial_progress_error(self, tmp_path, monkeypatch):
         # A flaky reader must not stall the import for an hour with no
         # explanation: the budget is checked between files.
         mount = tmp_path / "card"
@@ -1278,12 +1243,8 @@ class TestCameraToolsDownloadFromMSC:
         # Clock: deadline calc, then one check per file. Budget blows after
         # the first file is copied.
         ticks = iter([0.0, 0.0, 500.0])
-        monkeypatch.setattr(
-            "darktable_mcp.tools.camera_tools.time.monotonic", lambda: next(ticks)
-        )
-        saved, skipped, errors = CameraTools()._download_from_msc(
-            mount, dest, timeout_seconds=120
-        )
+        monkeypatch.setattr("darktable_mcp.tools.camera_tools.time.monotonic", lambda: next(ticks))
+        saved, skipped, errors = CameraTools()._download_from_msc(mount, dest, timeout_seconds=120)
         assert saved == 1
         assert len(errors) == 1
         assert "Timed out after 120 s" in errors[0]
@@ -1316,9 +1277,7 @@ class TestCameraToolsHybridDispatch:
         self, mock_msc, _mock_list, _mock_count, mock_download, tmp_path
     ):
         mock_download.return_value = (3, 0, [])
-        CameraTools()._download_from_camera(
-            "Nikon DSC D800E", "usb:002,003", tmp_path
-        )
+        CameraTools()._download_from_camera("Nikon DSC D800E", "usb:002,003", tmp_path)
         mock_msc.assert_not_called()
 
 
@@ -1359,10 +1318,12 @@ class TestCameraToolsImportFromCameraHybrid:
         tools = CameraTools()
         # Picking the MSC port still pulls the whole group (because the
         # pair is one logical device).
-        tools.import_from_camera({
-            "destination": str(tmp_path),
-            "camera_port": "disk:/media/user/NIKON D800E",
-        })
+        tools.import_from_camera(
+            {
+                "destination": str(tmp_path),
+                "camera_port": "disk:/media/user/NIKON D800E",
+            }
+        )
         assert mock_download.call_count == 2
 
     @patch.object(CameraTools, "_download_from_camera")
@@ -1436,9 +1397,7 @@ class TestCameraToolsSerialProbe:
 
     @patch("darktable_mcp.tools.camera_tools.subprocess.run")
     def test_all_zero_serial_is_not_an_identity(self, mock_run):
-        mock_run.return_value = Mock(
-            returncode=0, stdout="Current: 0000000000000000\n", stderr=""
-        )
+        mock_run.return_value = Mock(returncode=0, stdout="Current: 0000000000000000\n", stderr="")
         assert _REAL_PROBE_SERIAL(CameraTools(), "Some Camera", "usb:001,001") is None
 
     @patch("darktable_mcp.tools.camera_tools.subprocess.run")
@@ -1551,15 +1510,11 @@ class TestCameraToolsCrossCameraCollisions:
         tools = CameraTools()
         serials = {"usb:002,002": "30014567", "usb:002,005": "30019999"}
 
-        with patch.object(
-            CameraTools, "_probe_serial", side_effect=lambda m, p: serials[p]
-        ):
+        with patch.object(CameraTools, "_probe_serial", side_effect=lambda m, p: serials[p]):
             mock_popen.side_effect = _FakeGphoto2(self.TREE, marker="BODY-A-")
             tools._download_from_camera("Nikon D850", "usb:002,002", tmp_path)
             mock_popen.side_effect = _FakeGphoto2(self.TREE, marker="BODY-B-")
-            saved, skipped, _ = tools._download_from_camera(
-                "Nikon D850", "usb:002,005", tmp_path
-            )
+            saved, skipped, _ = tools._download_from_camera("Nikon D850", "usb:002,005", tmp_path)
 
         assert (saved, skipped) == (1, 0)
         landed = sorted(str(p.relative_to(tmp_path)) for p in tmp_path.rglob("*.NEF"))
@@ -1619,9 +1574,7 @@ class TestCameraToolsCrossCameraCollisions:
     ):
         mock_list.return_value = ["/a", "/b", "/c"]
         mock_download.return_value = (1, 0, [])
-        with patch.object(
-            CameraTools, "_probe_serial", return_value="30014567"
-        ) as mock_probe:
+        with patch.object(CameraTools, "_probe_serial", return_value="30014567") as mock_probe:
             CameraTools()._download_from_camera("Nikon D850", "usb:002,002", tmp_path)
         assert mock_download.call_count == 3
         assert mock_probe.call_count == 1
@@ -1714,9 +1667,7 @@ class TestCameraToolsDistinctName:
         assert CameraTools._distinct_name("RAWFILE", 2) == "RAWFILE-2"
 
     def test_only_the_last_dot_is_treated_as_the_extension(self):
-        assert CameraTools._distinct_name("IMG_0001.sidecar.xmp", 2) == (
-            "IMG_0001.sidecar-2.xmp"
-        )
+        assert CameraTools._distinct_name("IMG_0001.sidecar.xmp", 2) == ("IMG_0001.sidecar-2.xmp")
 
 
 class TestCameraToolsMSCNeverDestroys:
@@ -1779,9 +1730,7 @@ class TestCameraToolsMSCNeverDestroys:
     def test_same_size_rerun_still_skips_and_reports_the_skip_count(self, tmp_path):
         mount = tmp_path / "card"
         dest = tmp_path / "out"
-        self._card(
-            mount, "100D800E", {"A.NEF": b"photo-one!!", "B.NEF": b"photo-two!!"}
-        )
+        self._card(mount, "100D800E", {"A.NEF": b"photo-one!!", "B.NEF": b"photo-two!!"})
         tools = CameraTools()
         assert tools._download_from_msc(mount, dest)[:2] == (2, 0)
 
@@ -1909,12 +1858,8 @@ class TestCameraToolsImportReportsNameConflicts:
 
     @patch.object(CameraTools, "_download_from_camera")
     @patch.object(CameraTools, "_detect_cameras")
-    def test_clean_import_has_no_conflict_section(
-        self, mock_detect, mock_download, tmp_path
-    ):
-        mock_detect.return_value = [
-            {"model": "Nikon DSC D800E", "port": "usb:002,002"}
-        ]
+    def test_clean_import_has_no_conflict_section(self, mock_detect, mock_download, tmp_path):
+        mock_detect.return_value = [{"model": "Nikon DSC D800E", "port": "usb:002,002"}]
         mock_download.return_value = (5, 0, [])
         summary = CameraTools().import_from_camera({"destination": str(tmp_path)})
         assert "name conflict" not in summary

--- a/tests/test_darktable.py
+++ b/tests/test_darktable.py
@@ -132,9 +132,7 @@ class TestCLIWrapperConfigdir:
         assert wrapper.configdir.is_dir()
 
     @patch("shutil.which", return_value="/usr/bin/darktable-cli")
-    def test_default_configdir_falls_back_to_home_cache(
-        self, _mock_which, tmp_path, monkeypatch
-    ):
+    def test_default_configdir_falls_back_to_home_cache(self, _mock_which, tmp_path, monkeypatch):
         monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
         monkeypatch.setenv("HOME", str(tmp_path))
         wrapper = CLIWrapper()
@@ -159,9 +157,7 @@ class TestCLIWrapperExport:
 
     @patch("darktable_mcp.darktable.cli_wrapper.subprocess.run")
     @patch("shutil.which", return_value="/usr/bin/darktable-cli")
-    def test_export_passes_configdir_to_darktable_cli(
-        self, _mock_which, mock_run, tmp_path
-    ):
+    def test_export_passes_configdir_to_darktable_cli(self, _mock_which, mock_run, tmp_path):
         mock_run.side_effect = fake_run()
         cfg = tmp_path / "cfg"
         wrapper = CLIWrapper(configdir=cfg)
@@ -185,9 +181,7 @@ class TestCLIWrapperExport:
 
     @patch("darktable_mcp.darktable.cli_wrapper.subprocess.run")
     @patch("shutil.which", return_value="/usr/bin/darktable-cli")
-    def test_export_failure_raises_export_error_with_stderr(
-        self, _mock_which, mock_run, tmp_path
-    ):
+    def test_export_failure_raises_export_error_with_stderr(self, _mock_which, mock_run, tmp_path):
         mock_run.side_effect = fake_run(returncode=1, stderr="database is locked")
         wrapper = CLIWrapper(configdir=tmp_path)
         with pytest.raises(ExportError, match="database is locked"):
@@ -199,9 +193,7 @@ class TestCLIWrapperExport:
         mock_run.side_effect = subprocess.TimeoutExpired(cmd=["darktable-cli"], timeout=5)
         wrapper = CLIWrapper(configdir=tmp_path)
         with pytest.raises(ExportError, match="timed out"):
-            wrapper.export_image(
-                Path("/in.NEF"), tmp_path / "out.jpg", "jpeg", timeout=5
-            )
+            wrapper.export_image(Path("/in.NEF"), tmp_path / "out.jpg", "jpeg", timeout=5)
 
 
 class TestCLIWrapperOutputVerification:
@@ -424,9 +416,7 @@ class TestBatchExportParallelism:
 
     @patch("darktable_mcp.darktable.cli_wrapper.subprocess.run")
     @patch("shutil.which", return_value="/usr/bin/darktable-cli")
-    def test_results_stay_in_input_order_under_parallelism(
-        self, _mock_which, mock_run, tmp_path
-    ):
+    def test_results_stay_in_input_order_under_parallelism(self, _mock_which, mock_run, tmp_path):
         def _run(cmd, *_args, **_kwargs):
             # Finish in reverse order so a naive as_completed collector scrambles.
             index = int(Path(cmd[1]).stem)
@@ -440,9 +430,7 @@ class TestBatchExportParallelism:
         results = wrapper.batch_export(inputs, tmp_path / "out", max_workers=8)
 
         assert [r.input for r in results] == [str(p) for p in inputs]
-        assert [r.output for r in results] == [
-            str(tmp_path / "out" / f"{i}.jpg") for i in range(8)
-        ]
+        assert [r.output for r in results] == [str(tmp_path / "out" / f"{i}.jpg") for i in range(8)]
 
     @patch("darktable_mcp.darktable.cli_wrapper.subprocess.run")
     @patch("shutil.which", return_value="/usr/bin/darktable-cli")
@@ -475,9 +463,7 @@ class TestBatchExportParallelism:
     def test_max_workers_defaults_without_argument(self, _mock_which, mock_run, tmp_path):
         mock_run.side_effect = fake_run()
         wrapper = CLIWrapper(configdir=tmp_path / "cfg")
-        results = wrapper.batch_export(
-            [Path(f"/src/{i}.NEF") for i in range(6)], tmp_path / "out"
-        )
+        results = wrapper.batch_export([Path(f"/src/{i}.NEF") for i in range(6)], tmp_path / "out")
 
         assert len(results) == 6
         assert all(r.ok for r in results)

--- a/tests/test_install_plugin.py
+++ b/tests/test_install_plugin.py
@@ -78,17 +78,14 @@ def test_install_overwrites_modified_plugin_file(tmp_path):
 def test_install_re_enables_commented_out_require(tmp_path):
     luarc_dir = tmp_path / ".config" / "darktable"
     luarc_dir.mkdir(parents=True)
-    (luarc_dir / "luarc").write_text(
-        '-- some other comment\n-- require "darktable_mcp"\n'
-    )
+    (luarc_dir / "luarc").write_text('-- some other comment\n-- require "darktable_mcp"\n')
     install(tmp_path)
     text = (luarc_dir / "luarc").read_text()
     # The commented-out form is still there (we don't touch it),
     # but a fresh active require line was appended.
     assert '-- require "darktable_mcp"' in text
     active_lines = [
-        ln for ln in text.splitlines()
-        if ln.split("--", 1)[0].rstrip() == 'require "darktable_mcp"'
+        ln for ln in text.splitlines() if ln.split("--", 1)[0].rstrip() == 'require "darktable_mcp"'
     ]
     assert len(active_lines) == 1
 
@@ -104,4 +101,4 @@ def test_uninstall_removes_require_with_inline_comment(tmp_path):
     uninstall(tmp_path)
     text = (luarc_dir / "luarc").read_text()
     assert 'require "other"' in text
-    assert 'darktable_mcp' not in text
+    assert "darktable_mcp" not in text

--- a/tests/test_lua_dispatcher.py
+++ b/tests/test_lua_dispatcher.py
@@ -62,8 +62,7 @@ def test_lua_dispatcher():
         timeout=60,
     )
     assert result.returncode == 0, (
-        f"Lua tests failed under {LUA_BIN}.\n"
-        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        f"Lua tests failed under {LUA_BIN}.\n" f"stdout: {result.stdout}\nstderr: {result.stderr}"
     )
     # Guard against a suite that exits 0 without having asserted anything
     # (e.g. an early `return` or a load failure swallowed somewhere).
@@ -120,9 +119,7 @@ def test_plugin_has_no_flat_poll_loop():
     worker = source.split("local function worker_loop", 1)
     assert len(worker) == 2, "worker_loop not found in the plugin"
     body = worker[1]
-    assert "dt.control.sleep(100)" not in body, (
-        "worker_loop still contains a hardcoded 100ms sleep"
-    )
+    assert "dt.control.sleep(100)" not in body, "worker_loop still contains a hardcoded 100ms sleep"
 
 
 def test_import_batch_does_not_echo_an_unhonoured_recursive_flag():
@@ -144,8 +141,7 @@ def test_import_batch_does_not_echo_an_unhonoured_recursive_flag():
         "darktable preference"
     )
     assert "recursive_honoured" in body, (
-        "import_batch does not report whether the requested recursion mode "
-        "actually happened"
+        "import_batch does not report whether the requested recursion mode " "actually happened"
     )
     # The plugin must not silently rewrite a persistent user preference.
     assert "preferences.write" not in source, (
@@ -211,6 +207,4 @@ def test_sweep_covers_orphan_responses():
     assert len(sweep) == 2, "sweep_stale not found in the plugin"
     body = sweep[1].split("\nend", 1)[0]
     assert '-name "request-*.json"' in body, "sweep no longer covers requests"
-    assert '-name "response-*.json"' in body, (
-        "sweep_stale does not delete orphan response files"
-    )
+    assert '-name "response-*.json"' in body, "sweep_stale does not delete orphan response files"

--- a/tests/test_preview_tools.py
+++ b/tests/test_preview_tools.py
@@ -100,9 +100,7 @@ class TestApplyRatingsBatch:
 
     def test_missing_raw_reported_per_item(self, tmp_path: Path) -> None:
         _touch(tmp_path / "DSC_0004.NEF")
-        result = apply_ratings_batch(
-            tmp_path, {"DSC_0004": 3, "DSC_NOPE": 4}, log=False
-        )
+        result = apply_ratings_batch(tmp_path, {"DSC_0004": 3, "DSC_NOPE": 4}, log=False)
         assert result["applied"] == 1
         assert result["errors"] == 1
         bad = next(it for it in result["items"] if it["stem"] == "DSC_NOPE")
@@ -112,9 +110,7 @@ class TestApplyRatingsBatch:
         _touch(tmp_path / "IMG_0001.cr2")
         _touch(tmp_path / "DSCF1234.RAF")
 
-        result = apply_ratings_batch(
-            tmp_path, {"IMG_0001": 4, "DSCF1234": 5}, log=False
-        )
+        result = apply_ratings_batch(tmp_path, {"IMG_0001": 4, "DSCF1234": 5}, log=False)
         assert result["applied"] == 2
         assert (tmp_path / "IMG_0001.cr2.xmp").exists()
         assert (tmp_path / "DSCF1234.RAF.xmp").exists()
@@ -392,9 +388,7 @@ class TestExtractPreviews:
         assert side.exists()
         assert side.read_text() == ""
 
-    def test_side_file_has_one_jsonl_line_per_item(
-        self, tmp_path: Path, monkeypatch
-    ) -> None:
+    def test_side_file_has_one_jsonl_line_per_item(self, tmp_path: Path, monkeypatch) -> None:
         """The full per-file detail moved out of the function's return into a
         JSONL side file. Verify the file is exactly one parseable line per item.
 
@@ -405,9 +399,7 @@ class TestExtractPreviews:
         from darktable_mcp.tools import preview_tools as pt
 
         # Stub the vision libs so the function can run without rawpy/PIL.
-        monkeypatch.setattr(
-            pt, "_import_vision_libs", lambda: (None, None, None, None)
-        )
+        monkeypatch.setattr(pt, "_import_vision_libs", lambda: (None, None, None, None))
         # Empty source dir → items list will be []; we need at least one fake
         # raw to exercise the per-file write path. Easiest: run twice — once
         # to produce an empty side file (covered above), and a second pass
@@ -420,9 +412,9 @@ class TestExtractPreviews:
         # recorded with an error — that's still a valid per-item record.
         result = pt.extract_previews(tmp_path)
         side = Path(result["side_file"])
-        lines = [json.loads(l) for l in side.read_text().splitlines()]
+        lines = [json.loads(line) for line in side.read_text().splitlines()]
         assert len(lines) == 2
-        assert {l["stem"] for l in lines} == {"DSC_0001", "DSC_0002"}
+        assert {line["stem"] for line in lines} == {"DSC_0001", "DSC_0002"}
         # Each line should be a complete record with the expected keys.
         for entry in lines:
             assert {"stem", "source", "preview", "exif", "size", "error"} <= entry.keys()
@@ -582,9 +574,7 @@ class TestThumbnailFormats:
         assert len(image_mod.open_calls) == 1
         assert Path(result["items"][0]["preview"]).exists()
 
-    def test_bitmap_thumb_goes_through_image_fromarray(
-        self, tmp_path: Path, monkeypatch
-    ) -> None:
+    def test_bitmap_thumb_goes_through_image_fromarray(self, tmp_path: Path, monkeypatch) -> None:
         # rawpy returns a numpy ndarray for ThumbFormat.BITMAP — Image.open
         # would choke on it, so it must take the fromarray path instead.
         rawpy_mod = _FakeRawpyModule(fmt=_FakeRawpyModule.ThumbFormat.BITMAP)
@@ -601,9 +591,7 @@ class TestThumbnailFormats:
         assert image_mod.open_calls == []  # never fed an ndarray
         assert item["size"] == [320, 240]
 
-    def test_bitmap_thumb_still_writes_the_small_thumb(
-        self, tmp_path: Path, monkeypatch
-    ) -> None:
+    def test_bitmap_thumb_still_writes_the_small_thumb(self, tmp_path: Path, monkeypatch) -> None:
         rawpy_mod = _FakeRawpyModule(fmt=_FakeRawpyModule.ThumbFormat.BITMAP)
         _install_fake_vision(monkeypatch, rawpy_mod)
         (tmp_path / "DSC_0003.NEF").write_bytes(b"raw")
@@ -622,8 +610,18 @@ class TestRawExtensionMatching:
         from darktable_mcp.tools.preview_tools import RAW_EXTENSIONS
 
         assert all(ext == ext.lower() for ext in RAW_EXTENSIONS)
-        assert {".srw", ".nrw", ".rwl", ".erf", ".mrw", ".x3f", ".iiq", ".3fr",
-                ".kdc", ".mos"} <= set(RAW_EXTENSIONS)
+        assert {
+            ".srw",
+            ".nrw",
+            ".rwl",
+            ".erf",
+            ".mrw",
+            ".x3f",
+            ".iiq",
+            ".3fr",
+            ".kdc",
+            ".mos",
+        } <= set(RAW_EXTENSIONS)
 
     def test_find_raws_matches_regardless_of_case(self, tmp_path: Path) -> None:
         from darktable_mcp.tools.preview_tools import _find_raws_for_stem
@@ -634,16 +632,24 @@ class TestRawExtensionMatching:
 
         assert [p.name for p in found] == ["DSC_9999.NeF"]
 
-    def test_mixed_case_and_extra_formats_are_discovered(
-        self, tmp_path: Path, monkeypatch
-    ) -> None:
+    def test_mixed_case_and_extra_formats_are_discovered(self, tmp_path: Path, monkeypatch) -> None:
         _install_fake_vision(monkeypatch, _FakeRawpyModule())
         names = [
-            "a.NEF", "b.nef", "c.Nef",       # case must not matter
-            "d.Cr2", "e.ARW", "f.srw",       # Samsung
-            "g.nrw", "h.rwl", "i.erf",
-            "j.mrw", "k.x3f", "l.iiq",
-            "m.3fr", "n.kdc", "o.mos",
+            "a.NEF",
+            "b.nef",
+            "c.Nef",  # case must not matter
+            "d.Cr2",
+            "e.ARW",
+            "f.srw",  # Samsung
+            "g.nrw",
+            "h.rwl",
+            "i.erf",
+            "j.mrw",
+            "k.x3f",
+            "l.iiq",
+            "m.3fr",
+            "n.kdc",
+            "o.mos",
         ]
         for name in names:
             (tmp_path / name).write_bytes(b"raw")
@@ -681,7 +687,10 @@ class TestParallelExtraction:
         result = extract_previews(tmp_path, thumb_dim=0, max_workers=4)
 
         assert [it["stem"] for it in result["items"]] == [
-            "DSC_0001", "DSC_0002", "DSC_0003", "DSC_0004",
+            "DSC_0001",
+            "DSC_0002",
+            "DSC_0003",
+            "DSC_0004",
         ]
         # The JSONL side file follows the same order.
         raw_lines = Path(result["side_file"]).read_text().splitlines()
@@ -782,9 +791,7 @@ class TestRecursiveExtraction:
         assert [it["stem"] for it in result["items"]] == ["DSC_0001", "DSC_0001"]
         assert len({it["source"] for it in result["items"]}) == 2
 
-    def test_recursive_items_stay_in_sorted_path_order(
-        self, tmp_path: Path, monkeypatch
-    ) -> None:
+    def test_recursive_items_stay_in_sorted_path_order(self, tmp_path: Path, monkeypatch) -> None:
         delays = {"DSC_0001": 0.15, "DSC_0002": 0.0}
         _install_fake_vision(monkeypatch, _FakeRawpyModule(delays=delays))
         for card in ("card_b", "card_a"):
@@ -817,9 +824,7 @@ class TestRecursiveExtraction:
         assert second["extracted"] == 0
         assert "STRAY_0001" not in {it["stem"] for it in second["items"]}
 
-    def test_custom_output_dir_inside_source_is_excluded(
-        self, tmp_path: Path, monkeypatch
-    ) -> None:
+    def test_custom_output_dir_inside_source_is_excluded(self, tmp_path: Path, monkeypatch) -> None:
         # A non-dot output_dir under source_dir would otherwise be re-scanned.
         _install_fake_vision(monkeypatch, _FakeRawpyModule())
         (tmp_path / "card_a").mkdir()
@@ -1282,9 +1287,7 @@ class TestLaunchVerification:
         # A hung child we spawned is ours to clean up.
         assert proc.killed is True
 
-    def test_lock_notice_with_clean_exit_reports_handoff(
-        self, tmp_path: Path, monkeypatch
-    ) -> None:
+    def test_lock_notice_with_clean_exit_reports_handoff(self, tmp_path: Path, monkeypatch) -> None:
         """The Linux case: the handoff succeeds and the images open in the running window."""
         proc = _FakePopen(
             exit_code=0,
@@ -1314,9 +1317,7 @@ class TestLaunchVerification:
         # The captured output is surfaced, not swallowed.
         assert "some other startup failure" in message
 
-    def test_immediate_exit_zero_also_reports_failure(
-        self, tmp_path: Path, monkeypatch
-    ) -> None:
+    def test_immediate_exit_zero_also_reports_failure(self, tmp_path: Path, monkeypatch) -> None:
         # darktable can bail with status 0 too; a dead child is a dead child.
         self._patch(monkeypatch, _FakePopen(exit_code=0))
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,9 +1,16 @@
 """Tests for the main MCP server."""
 
+import difflib
+import json
 from contextlib import asynccontextmanager
+from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
+import anyio
 import pytest
+from mcp.client import ClientSession
+from mcp.shared.memory import create_client_server_memory_streams
+from mcp.types import CallToolResult, TextContent, Tool
 
 from darktable_mcp.server import DarktableMCPServer
 
@@ -451,7 +458,7 @@ def test_cli_batch_export_accepts_the_max_dimensions_the_handler_sends():
 def test_export_images_schema_exposes_size_limits_but_not_tuning_knobs():
     server = DarktableMCPServer()
     tool = next(t for t in server._tool_definitions() if t.name == "export_images")
-    props = tool.inputSchema["properties"]
+    props = tool.input_schema["properties"]
 
     assert props["max_width"]["type"] == "integer"
     assert props["max_height"]["type"] == "integer"
@@ -672,3 +679,525 @@ def test_import_from_camera_description_is_honest_about_cost():
 
     assert "synchronously" in desc
     assert ".import.log" in desc
+
+
+# ---------------------------------------------------------------------------
+# Golden snapshot of the agent-facing tool contract
+# ---------------------------------------------------------------------------
+#
+# The complete wire form of `tools/list`: for all ten tools, the exact name,
+# the exact description, and the exact inputSchema down to every `minimum`,
+# `maximum`, `default`, `enum`, `additionalProperties` and `required` entry.
+#
+# This exists because the descriptions ARE the contract. The calling model
+# reads them to decide behaviour, and several encode warnings that took real
+# incidents to learn: `force` is destructive, export output names are
+# de-collided, camera files land one subdirectory per card, a card import
+# blocks synchronously for up to an hour. A port that reworded any of that, or
+# quietly dropped a bound, would leave every unit test green and change what
+# the agent does.
+#
+# The literal below was captured from the pre-port (mcp 1.x) server and then
+# verified byte-for-byte against the mcp 2.x port, so it pins the 1.x contract,
+# not merely whatever the current code happens to emit. Update it only when the
+# tool surface is deliberately changed.
+
+EXPECTED_TOOL_CONTRACT: list[dict[str, Any]] = [
+    {
+        "name": "view_photos",
+        "description": (
+            "Browse photos in the user's darktable library. Filter by "
+            "filename substring, minimum star rating, or both. Returns id, "
+            "filename, absolute file path, and rating per match — the path "
+            "can be passed straight into export_images. Requires darktable "
+            "to be running with the darktable-mcp Lua plugin installed "
+            "(see darktable-mcp install-plugin)."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "filter": {
+                    "type": "string",
+                    "description": "Substring filter on filename (case-insensitive)",
+                },
+                "rating_min": {
+                    "type": "integer",
+                    "minimum": -1,
+                    "maximum": 5,
+                    "description": "Minimum star rating to include",
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 1000,
+                    "default": 100,
+                    "description": "Maximum number of photos to return",
+                },
+            },
+        },
+    },
+    {
+        "name": "rate_photos",
+        "description": (
+            "Apply a star rating to one or more photos in the user's "
+            "darktable library. Requires darktable to be running with the "
+            "darktable-mcp Lua plugin installed."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "photo_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                    },
+                    "description": "List of photo IDs (from view_photos)",
+                },
+                "rating": {
+                    "type": "integer",
+                    "minimum": -1,
+                    "maximum": 5,
+                    "description": "Star rating: -1=reject, 0=unrated, 1-5=stars",
+                },
+            },
+            "required": ["photo_ids", "rating"],
+        },
+    },
+    {
+        "name": "import_batch",
+        "description": (
+            "Register a folder as a film roll in the user's darktable "
+            "library. Useful when you've copied photos from a card or "
+            "external drive and want darktable to know about them. Returns "
+            "the count of newly-imported photos. Requires darktable to be "
+            "running with the darktable-mcp Lua plugin installed."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "source_path": {
+                    "type": "string",
+                    "description": "Absolute path to the folder of photos to import",
+                },
+                "recursive": {
+                    "type": "boolean",
+                    "default": True,
+                    "description": "Recurse into subdirectories (default true)",
+                },
+            },
+            "required": ["source_path"],
+        },
+    },
+    {
+        "name": "list_styles",
+        "description": (
+            "List all darktable styles (presets) installed on the user's "
+            "system. Returns name and description for each. Required "
+            "discovery step before calling apply_preset, since style names "
+            "must match exactly. Requires darktable to be running with the "
+            "darktable-mcp Lua plugin installed."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {},
+        },
+    },
+    {
+        "name": "apply_preset",
+        "description": (
+            "Apply a darktable style (preset) to one or more photos. The "
+            "preset_name must exactly match a style name from list_styles. "
+            "Returns counts of applied and missed photos. Requires "
+            "darktable to be running with the darktable-mcp Lua plugin "
+            "installed."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "photo_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                    },
+                    "description": "Photo IDs (from view_photos)",
+                },
+                "preset_name": {
+                    "type": "string",
+                    "description": "Style name (must match exactly; see list_styles)",
+                },
+            },
+            "required": ["photo_ids", "preset_name"],
+        },
+    },
+    {
+        "name": "import_from_camera",
+        "description": (
+            "Use when a camera or memory card is physically connected. "
+            "Detects the camera via libgphoto2 and copies all photos to a "
+            "local directory, then returns the destination path. Copying "
+            "alone does not put the photos in the library: follow up with "
+            "import_batch on that destination path to register them as a "
+            "film roll. Files are written one subdirectory per camera "
+            "folder or card, prefixed with the camera's identity (e.g. "
+            "<destination>/Nikon_D850_sn_30014567_store_00010001_DCIM_100NCD80/DSC_0001.NEF), "
+            "because camera filenames repeat across folders, across the "
+            "two cards of a dual-slot body, and across bodies importing "
+            "into the same destination. Import the destination "
+            "recursively. A file that would collide with a different photo "
+            "already on disk is kept alongside it as <name>-2.<ext>, never "
+            "overwritten. This holds for two bodies of the same model that "
+            "report no serial number and therefore share a subdirectory: "
+            "before skipping files a destination appears to already hold, "
+            "such a camera is asked for a small sample of them and the bytes "
+            "are compared, so a second body's photos are kept rather than "
+            "dropped. Re-running is cheap: a body with a serial number "
+            "transfers nothing it already delivered. Any file the card lists "
+            "that does not reach the destination is reported by name. "
+            "Cost: this tool runs to completion "
+            "synchronously and does not return early. A full card can take "
+            "many minutes, up to the 1 hour default timeout, which is "
+            "longer than most MCP clients wait for a single request. "
+            "Progress is observable while it runs by tailing the "
+            ".import.log file in the destination directory."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "destination": {
+                    "type": "string",
+                    "description": (
+                        "Target directory for copied files. Default: "
+                        "~/Pictures/import-YYYY-MM-DD/"
+                    ),
+                },
+                "camera_port": {
+                    "type": "string",
+                    "description": (
+                        "gphoto2 port string (e.g. 'usb:002,002'). Required when "
+                        "multiple cameras are connected."
+                    ),
+                },
+                "timeout_seconds": {
+                    "type": "integer",
+                    "minimum": 60,
+                    "description": (
+                        "Overall time budget for the transfer from one camera, shared "
+                        "across all of its folders (not per folder). Default: 3600 (1 "
+                        "hour). On timeout, re-run the tool to resume — already-copied "
+                        "files are skipped."
+                    ),
+                },
+            },
+        },
+    },
+    {
+        "name": "extract_previews",
+        "description": (
+            "Extract auto-rotated JPEG previews from a directory of raw "
+            "files (NEF/CR2/ARW/DNG/etc) for vision-based rating. Each "
+            "preview is rotated upright via EXIF orientation and resized "
+            "to max_dim (default 1024). A smaller thumb_dim (default 384) "
+            "is also written for token-efficient first-pass culling. "
+            "Returns a list of items with preview paths plus an EXIF "
+            "summary (ISO, shutter, focal, aperture, datetime) per file. "
+            "The scan is recursive, and the output tree mirrors the source "
+            "tree, so raws with the same filename in different "
+            "subdirectories get distinct previews. Read the preview path "
+            "from each item rather than assuming <output_dir>/<stem>.jpg."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "source_dir": {
+                    "type": "string",
+                    "description": "Directory containing raw files",
+                },
+                "output_dir": {
+                    "type": "string",
+                    "description": "Where to write JPEGs. Default: <source_dir>/.previews/",
+                },
+                "max_dim": {
+                    "type": "integer",
+                    "minimum": 256,
+                    "maximum": 4096,
+                    "default": 1024,
+                    "description": "Longest-edge for the standard preview",
+                },
+                "thumb_dim": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 1024,
+                    "default": 384,
+                    "description": "Thumb longest-edge; 0 to skip",
+                },
+                "overwrite": {
+                    "type": "boolean",
+                    "default": False,
+                    "description": "Re-extract even if preview exists",
+                },
+                "max_workers": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 32,
+                    "description": (
+                        "Parallel decode workers. Default: min(8, cpu_count). Lower it "
+                        "if the machine is memory-constrained."
+                    ),
+                },
+            },
+            "required": ["source_dir"],
+        },
+    },
+    {
+        "name": "apply_ratings_batch",
+        "description": (
+            "Write XMP sidecars (xmp:Rating) for a batch of {stem: rating} "
+            "pairs. Each sidecar sits next to its raw file at <raw "
+            "path>.xmp and is picked up automatically by darktable on "
+            "import. Rating range: -1 (reject), 0 (unrated), 1-5 (stars). "
+            "Each rating is also appended to <source_dir>/ratings.jsonl "
+            "for replay/audit. An existing sidecar is never replaced: only "
+            "its rating value is rewritten, so darktable edit history "
+            "survives. A sidecar with no recognisable rating is skipped "
+            "with an error rather than overwritten."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "source_dir": {
+                    "type": "string",
+                    "description": "Directory holding the raw files",
+                },
+                "ratings": {
+                    "type": "object",
+                    "description": (
+                        "Map of file stem (e.g. 'DSC_1234') to rating int in [-1, 5]. "
+                        "When the same stem occurs in more than one subdirectory the "
+                        "bare stem is rejected as ambiguous — use a source-relative "
+                        "path instead (e.g. 'store_00010001_DCIM_100NCD80/DSC_1234')."
+                    ),
+                    "additionalProperties": {
+                        "type": "integer",
+                        "minimum": -1,
+                        "maximum": 5,
+                    },
+                },
+                "log": {
+                    "type": "boolean",
+                    "default": True,
+                    "description": "Append entries to ratings.jsonl",
+                },
+                "force": {
+                    "type": "boolean",
+                    "default": False,
+                    "description": (
+                        "Destructive: replace an existing sidecar wholesale instead of "
+                        "patching its rating. This discards any darktable edit history "
+                        "in that file. Only use when the user has explicitly asked to "
+                        "reset the sidecars."
+                    ),
+                },
+            },
+            "required": ["source_dir", "ratings"],
+        },
+    },
+    {
+        "name": "open_in_darktable",
+        "description": (
+            "Launch the darktable GUI on a folder. The folder is "
+            "registered as a film roll on first launch and XMP sidecars "
+            "are picked up automatically. The lighttable opens already "
+            "filtered via the official `darktable.gui.libs.collect.filter` "
+            "Lua API for any rating spec: exact `rating=N`, `rating_min=N` "
+            "(>=), `rating_max=N` (<=), arbitrary `rating_min..rating_max` "
+            "inner ranges, or no filter at all."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "source_dir": {
+                    "type": "string",
+                    "description": "Folder containing the raw files",
+                },
+                "rating": {
+                    "type": "integer",
+                    "minimum": -1,
+                    "maximum": 5,
+                    "description": (
+                        "Filter to exactly this rating (-1=reject, 0=unrated, " "1-5=stars)"
+                    ),
+                },
+                "rating_min": {
+                    "type": "integer",
+                    "minimum": -1,
+                    "maximum": 5,
+                    "description": "Lower bound of a rating range",
+                },
+                "rating_max": {
+                    "type": "integer",
+                    "minimum": -1,
+                    "maximum": 5,
+                    "description": "Upper bound of a rating range",
+                },
+                "darktable_path": {
+                    "type": "string",
+                    "default": "darktable",
+                    "description": "darktable executable (default: 'darktable' on PATH)",
+                },
+            },
+            "required": ["source_dir"],
+        },
+    },
+    {
+        "name": "export_images",
+        "description": (
+            "Export photos to JPEG/PNG/TIFF via darktable-cli. Pass "
+            "absolute file paths in photo_ids — the `path` field from "
+            "view_photos drops in directly. Output names are de-collided: "
+            "two sources sharing a stem (e.g. DSC_0001.NEF from two "
+            "folders) get suffixed names rather than overwriting each "
+            "other, so do not assume the written file is <stem>.<format>. "
+            "Read the real path from the `output` field of the "
+            ".export_images.jsonl side file."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "photo_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                    },
+                    "description": "Absolute paths to source images",
+                },
+                "output_path": {
+                    "type": "string",
+                },
+                "format": {
+                    "type": "string",
+                    "enum": ["jpeg", "png", "tiff"],
+                },
+                "quality": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 100,
+                },
+                "max_width": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": (
+                        "Constrain the output width in pixels; aspect ratio is "
+                        "preserved. Omit for full resolution."
+                    ),
+                },
+                "max_height": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": (
+                        "Constrain the output height in pixels; aspect ratio is "
+                        "preserved. Omit for full resolution."
+                    ),
+                },
+            },
+            "required": ["photo_ids", "output_path", "format"],
+        },
+    },
+]
+
+
+def _wire(tools: list[Tool]) -> list[dict[str, Any]]:
+    """The exact JSON a client sees for each tool, with unset fields omitted."""
+    return [t.model_dump(by_alias=True, exclude_none=True, mode="json") for t in tools]
+
+
+def _contract_drift(actual: list[dict[str, Any]], expected: list[dict[str, Any]]) -> str:
+    """A readable unified diff of the whole contract, golden vs. served."""
+
+    def render(contract: list[dict[str, Any]]) -> list[str]:
+        # sort_keys so a harmless key reordering never masquerades as drift;
+        # dict equality is order-insensitive, and so is this rendering.
+        return json.dumps(contract, indent=2, ensure_ascii=False, sort_keys=True).splitlines()
+
+    diff = difflib.unified_diff(
+        render(expected), render(actual), "golden (EXPECTED_TOOL_CONTRACT)", "served by the server"
+    )
+    return "\n".join(
+        [
+            "",
+            "TOOL CONTRACT DRIFT: what the server serves no longer matches the",
+            "golden snapshot in tests/test_server.py. A description reworded or a",
+            "schema constraint dropped here silently changes agent behaviour.",
+            "If the change is intentional, update EXPECTED_TOOL_CONTRACT.",
+            "",
+            *diff,
+        ]
+    )
+
+
+def test_tool_definitions_match_the_golden_contract():
+    actual = _wire(DarktableMCPServer()._tool_definitions())
+    assert actual == EXPECTED_TOOL_CONTRACT, _contract_drift(actual, EXPECTED_TOOL_CONTRACT)
+
+
+def test_golden_contract_covers_every_registered_tool():
+    """Guards the snapshot against a tool being added without being pinned."""
+    server = DarktableMCPServer()
+    assert [t["name"] for t in EXPECTED_TOOL_CONTRACT] == [
+        t.name for t in server._tool_definitions()
+    ]
+    assert {t["name"] for t in EXPECTED_TOOL_CONTRACT} == set(server.list_tools())
+
+
+@pytest.mark.asyncio
+async def test_serves_the_golden_contract_over_a_real_mcp_session():
+    """Drive the server through a real MCP session with the SDK's own client.
+
+    Every other test in this file calls handler methods directly, so none of
+    them touch the transport. This one performs the initialize handshake,
+    lists tools, and calls one end to end over the SDK's in-memory streams —
+    the only evidence that the mcp 2.x wiring (`on_list_tools` / `on_call_tool`
+    on the low-level `Server`) is actually connected.
+
+    `export_images` with an empty `photo_ids` is the safe end-to-end call: it
+    fails validation and returns before reaching darktable or darktable-cli.
+    """
+    server = DarktableMCPServer()
+
+    async with create_client_server_memory_streams() as (client_streams, server_streams):
+        async with anyio.create_task_group() as tg:
+
+            async def run_server() -> None:
+                await server.app.run(
+                    server_streams[0],
+                    server_streams[1],
+                    server.app.create_initialization_options(),
+                    raise_exceptions=True,
+                )
+
+            tg.start_soon(run_server)
+
+            async with ClientSession(client_streams[0], client_streams[1]) as session:
+                init = await session.initialize()
+                assert init.server_info.name == "darktable-mcp"
+                assert init.capabilities.tools is not None, "server advertised no tools capability"
+
+                listed = await session.list_tools()
+                served = _wire(listed.tools)
+                assert served == EXPECTED_TOOL_CONTRACT, _contract_drift(
+                    served, EXPECTED_TOOL_CONTRACT
+                )
+
+                result = await session.call_tool(
+                    "export_images",
+                    {"photo_ids": [], "output_path": "/nonexistent", "format": "jpeg"},
+                )
+
+            tg.cancel_scope.cancel()
+
+    assert isinstance(result, CallToolResult)
+    # A validation refusal is tool output, not a transport error — the same
+    # contract open_in_darktable depends on for its raised DarktableMCPError.
+    assert result.is_error is False
+    assert [c.text for c in result.content if isinstance(c, TextContent)] == [
+        "photo_ids must contain at least one path"
+    ]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -40,9 +40,10 @@ class TestDarktableMCPServer:
         async def fake_stdio():
             yield (AsyncMock(), AsyncMock())
 
-        with patch("darktable_mcp.server.stdio_server", fake_stdio), patch.object(
-            server.app, "run", new=AsyncMock(return_value=None)
-        ) as mock_run:
+        with (
+            patch("darktable_mcp.server.stdio_server", fake_stdio),
+            patch.object(server.app, "run", new=AsyncMock(return_value=None)) as mock_run,
+        ):
             await server.start()
             mock_run.assert_called_once()
 
@@ -89,9 +90,7 @@ async def test_handle_view_photos_returns_formatted_list():
     # export_images don't compose.
     assert "/photos/a.NEF" in text
     assert "/photos/b.NEF" in text
-    server.bridge.call.assert_called_once_with(
-        "view_photos", {"filter": "", "limit": 10}
-    )
+    server.bridge.call.assert_called_once_with("view_photos", {"filter": "", "limit": 10})
 
 
 @pytest.mark.asyncio
@@ -147,9 +146,7 @@ async def test_handle_import_batch_returns_count():
     result = await server._handle_import_batch({"source_path": "/path/foo"})
     assert "Imported 12" in result[0].text
     assert "/path/foo" in result[0].text
-    server.bridge.call.assert_called_once_with(
-        "import_batch", {"source_path": "/path/foo"}
-    )
+    server.bridge.call.assert_called_once_with("import_batch", {"source_path": "/path/foo"})
 
 
 @pytest.mark.asyncio
@@ -217,9 +214,12 @@ async def test_handle_apply_preset_returns_applied_count():
     server = DarktableMCPServer()
     server.bridge = Mock()
     server.bridge.call.return_value = {"applied": 3, "missed": [], "preset_name": "myStyle"}
-    result = await server._handle_apply_preset({
-        "photo_ids": ["1", "2", "3"], "preset_name": "myStyle",
-    })
+    result = await server._handle_apply_preset(
+        {
+            "photo_ids": ["1", "2", "3"],
+            "preset_name": "myStyle",
+        }
+    )
     text = result[0].text
     assert "myStyle" in text
     assert "3 photo" in text
@@ -230,11 +230,16 @@ async def test_handle_apply_preset_reports_missed():
     server = DarktableMCPServer()
     server.bridge = Mock()
     server.bridge.call.return_value = {
-        "applied": 1, "missed": ["999"], "preset_name": "myStyle",
+        "applied": 1,
+        "missed": ["999"],
+        "preset_name": "myStyle",
     }
-    result = await server._handle_apply_preset({
-        "photo_ids": ["1", "999"], "preset_name": "myStyle",
-    })
+    result = await server._handle_apply_preset(
+        {
+            "photo_ids": ["1", "999"],
+            "preset_name": "myStyle",
+        }
+    )
     text = result[0].text
     assert "999" in text
     assert "Missed" in text
@@ -247,9 +252,12 @@ async def test_handle_apply_preset_friendly_error_when_dt_not_running():
     server = DarktableMCPServer()
     server.bridge = Mock()
     server.bridge.call.side_effect = BridgeTimeoutError("timeout")
-    result = await server._handle_apply_preset({
-        "photo_ids": ["1"], "preset_name": "x",
-    })
+    result = await server._handle_apply_preset(
+        {
+            "photo_ids": ["1"],
+            "preset_name": "x",
+        }
+    )
     assert "darktable" in result[0].text.lower()
 
 
@@ -271,12 +279,14 @@ async def test_handle_export_images_writes_side_file_and_short_summary(tmp_path)
     server._cli = Mock()
     server._cli.batch_export.return_value = fake_results
 
-    result = await server._handle_export_images({
-        "photo_ids": ["/in/A.NEF", "/in/B.NEF", "/in/C.NEF"],
-        "output_path": str(tmp_path),
-        "format": "jpeg",
-        "quality": 95,
-    })
+    result = await server._handle_export_images(
+        {
+            "photo_ids": ["/in/A.NEF", "/in/B.NEF", "/in/C.NEF"],
+            "output_path": str(tmp_path),
+            "format": "jpeg",
+            "quality": 95,
+        }
+    )
     text = result[0].text
 
     # Summary stays compact: counts + side file pointer + first error.
@@ -320,11 +330,13 @@ async def test_handle_export_images_trusts_ok_not_the_output_string(tmp_path):
         ),
     ]
 
-    result = await server._handle_export_images({
-        "photo_ids": ["/in/A.NEF"],
-        "output_path": str(tmp_path),
-        "format": "jpeg",
-    })
+    result = await server._handle_export_images(
+        {
+            "photo_ids": ["/in/A.NEF"],
+            "output_path": str(tmp_path),
+            "format": "jpeg",
+        }
+    )
     assert "exported: 1, failed: 0" in result[0].text
 
 
@@ -347,11 +359,13 @@ async def test_handle_export_images_offloads_the_batch(tmp_path):
     server._cli = Mock()
     server._cli.batch_export.side_effect = slow_batch_export
 
-    await server._handle_export_images({
-        "photo_ids": ["/in/A.NEF"],
-        "output_path": str(tmp_path),
-        "format": "jpeg",
-    })
+    await server._handle_export_images(
+        {
+            "photo_ids": ["/in/A.NEF"],
+            "output_path": str(tmp_path),
+            "format": "jpeg",
+        }
+    )
     assert seen["thread"] != loop_thread, "batch_export ran on the event loop thread"
 
 
@@ -376,13 +390,15 @@ async def test_handle_export_images_threads_max_dimensions_through(tmp_path):
         ExportResult(input="/in/A.NEF", output=f"{tmp_path}/A.jpg", ok=True, error=None),
     ]
 
-    await server._handle_export_images({
-        "photo_ids": ["/in/A.NEF"],
-        "output_path": str(tmp_path),
-        "format": "jpeg",
-        "max_width": 2048,
-        "max_height": 1536,
-    })
+    await server._handle_export_images(
+        {
+            "photo_ids": ["/in/A.NEF"],
+            "output_path": str(tmp_path),
+            "format": "jpeg",
+            "max_width": 2048,
+            "max_height": 1536,
+        }
+    )
     kwargs = server._cli.batch_export.call_args.kwargs
     assert kwargs["max_width"] == 2048
     assert kwargs["max_height"] == 1536
@@ -398,11 +414,13 @@ async def test_handle_export_images_defaults_max_dimensions_to_none(tmp_path):
         ExportResult(input="/in/A.NEF", output=f"{tmp_path}/A.jpg", ok=True, error=None),
     ]
 
-    await server._handle_export_images({
-        "photo_ids": ["/in/A.NEF"],
-        "output_path": str(tmp_path),
-        "format": "jpeg",
-    })
+    await server._handle_export_images(
+        {
+            "photo_ids": ["/in/A.NEF"],
+            "output_path": str(tmp_path),
+            "format": "jpeg",
+        }
+    )
     kwargs = server._cli.batch_export.call_args.kwargs
     assert kwargs["max_width"] is None
     assert kwargs["max_height"] is None
@@ -462,7 +480,7 @@ class TestBridgeErrorMappingIsSharedOnce:
         from darktable_mcp import server as server_module
 
         source = inspect.getsource(server_module)
-        assert source.count("darktable-mcp install-plugin\",") == 1
+        assert source.count('darktable-mcp install-plugin",') == 1
         assert source.count("bridge timeout") == 1
         assert source.count('text=f"Plugin error: {e}"') == 1
 
@@ -493,7 +511,7 @@ class TestBridgeErrorMappingIsSharedOnce:
 
 @pytest.mark.asyncio
 async def test_timeout_message_names_the_budget_and_both_causes():
-    """"darktable not running" was a lie for a slow-but-alive call. The text
+    """ "darktable not running" was a lie for a slow-but-alive call. The text
     must name the budget that elapsed and offer both explanations."""
     from darktable_mcp.bridge.client import DEFAULT_TIMEOUTS, BridgeTimeoutError
 
@@ -579,8 +597,9 @@ async def test_handle_extract_previews_offloads():
         seen["thread"] = threading.get_ident()
         return {"items": [], "count": 0}
 
-    with patch("darktable_mcp.server.extract_previews", side_effect=slow_extract), patch(
-        "darktable_mcp.server.format_extract_summary", return_value="done"
+    with (
+        patch("darktable_mcp.server.extract_previews", side_effect=slow_extract),
+        patch("darktable_mcp.server.format_extract_summary", return_value="done"),
     ):
         server = DarktableMCPServer()
         result = await server._handle_extract_previews({"source_dir": "/raws"})
@@ -600,8 +619,9 @@ async def test_handle_apply_ratings_batch_offloads():
         seen["thread"] = threading.get_ident()
         return {"written": 1}
 
-    with patch("darktable_mcp.server.apply_ratings_batch", side_effect=slow_apply), patch(
-        "darktable_mcp.server.format_ratings_summary", return_value="done"
+    with (
+        patch("darktable_mcp.server.apply_ratings_batch", side_effect=slow_apply),
+        patch("darktable_mcp.server.format_ratings_summary", return_value="done"),
     ):
         server = DarktableMCPServer()
         result = await server._handle_apply_ratings_batch(
@@ -623,8 +643,9 @@ async def test_handle_open_in_darktable_offloads():
         seen["thread"] = threading.get_ident()
         return {"launched": True}
 
-    with patch("darktable_mcp.server.open_in_darktable", side_effect=slow_open), patch(
-        "darktable_mcp.server.format_open_summary", return_value="done"
+    with (
+        patch("darktable_mcp.server.open_in_darktable", side_effect=slow_open),
+        patch("darktable_mcp.server.format_open_summary", return_value="done"),
     ):
         server = DarktableMCPServer()
         result = await server._handle_open_in_darktable({"source_dir": "/raws"})


### PR DESCRIPTION
The four follow-ups left open by #7.

## mcp 2.x port

The `<2` pin was a stopgap. 2.x is now the floor; tools register through the low-level `Server(on_list_tools=…, on_call_tool=…)` handlers.

Deliberately **not** the high-level `MCPServer` — measured, not assumed. It derives `inputSchema` from the handler signature, which cannot express `additionalProperties: {type: integer, minimum: -1, maximum: 5}`, so the rating bounds on `apply_ratings_batch` silently vanish, and it injects a `title` into every property.

The tool descriptions are what the calling model reads to decide behaviour, so the contract is pinned by a **golden-snapshot test** captured from the pre-port 1.x output and verified byte-identical across all 10 tools. Proved over a real MCP session — in-process via `ClientSession`, and as a stdio subprocess speaking hand-written JSON-RPC — because a green mocked suite says nothing about the transport.

## Release pipeline

Trusted publishing via OIDC; no token in repo secrets. Publish is gated behind the full matrix, guards that the git tag matches `__version__`, re-runs the shipped sdist's own suite, and installs the wheel into a clean venv outside the checkout — asserting the packaged Lua plugin is present, since `darktable-mcp install-plugin` is the first thing every user runs.

**That verification immediately found a real bug:** the sdist shipped without `tests/__init__.py` and `tests/lua/test_dispatcher.lua`, because setuptools' defaults take `tests/test_*.py` and nothing else. The published source distribution could not run its own suite (`lua: cannot open tests/lua/test_dispatcher.lua`). Fixed with `MANIFEST.in`; the built sdist now runs all 415 tests from a fresh venv.

⚠️ **One-time setup on your side before the first release** — PyPI → Manage account → Publishing → *pending publisher*: owner `w1ne`, repo `darktable-mcp`, workflow `release.yml`, environment `pypi`. Same on TestPyPI with `testpypi`. Then create both GitHub environments; the names must match exactly or PyPI rejects the OIDC token.

## Lint is now a real gate

170 ruff findings → 0, black clean, `continue-on-error` removed. 161 were typing modernisation that only became available when the floor moved to 3.10, i.e. mostly created by our own `requires-python` bump.

The one over-long line was substantive: the camera import summary still told users to "open darktable and choose import folder", guidance predating `import_batch` that we'd already corrected in the tool description. The two now agree.

## Camera same-model gap

The last known way to lose a photo. Two bodies of one model reporting no serial share a destination tag, and the PTP path let gphoto2's `--skip-existing` decide — it compares nothing but the path, so the second body's `DSC_0001.NEF` was silently dropped.

Downloads now land in a private staging directory and are placed through the same never-overwrite logic the card path already used, so a conflict yields `DSC_0001-2.NEF` instead of a skip. Resume stays cheap: `--list-files` says what to fetch, a body with a serial transfers nothing it already delivered, and one without has a bounded sample of its would-be-skipped files byte-compared first.

Also fixed on the way: a timeout used to leave a **truncated** file that `--skip-existing` would then protect forever. And every file the card lists that fails to arrive is now reported by name.

**Residual limit, stated rather than papered over:** the sample is bounded at 3 files per folder, so a second body matching on every sampled file in a larger folder is still taken for the first. Folders with ≤3 candidates are checked exhaustively. This is in the class docstring, the tool description, and the README — and pinned by a test so it cannot be quietly forgotten.

## Verification

**Tests: 375 → 415**, lint clean, and the shipped sdist runs all 415 from a fresh venv outside the repo. Every fix carries a negative control; the camera work's control for the core case fails as `saved == 2 → 0`, which is the data-loss shape itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
